### PR TITLE
Atoms workflow

### DIFF
--- a/beep/binding_energy_compute.py
+++ b/beep/binding_energy_compute.py
@@ -316,6 +316,13 @@ def compute_hessian(
     mols = df_all[df_all['stoichiometry'] == 'be_nocp']['molecule']
     u_mols = list(set(mols))
 
+    # Special case for atoms: removes id if its an atom
+    mol_list = client.query_molecules(u_mols)
+    for m in mol_list:
+        if len(m.symbols) == 1:
+            logger.info(f"\nAtom id {m.id} removed")
+            u_mols.remove(m.id)
+
     log_formatted_list(logger, u_mols, "Sending Hessian computations for the following molecules:", max_rows=5)
 
     # Set keywords depending on the multiplicity

--- a/workflows/launch_be_hess.py
+++ b/workflows/launch_be_hess.py
@@ -139,7 +139,10 @@ def check_collections(client: ptl.FractalClient, surface_model_name: str, molecu
         raise KeyError
     
     try:
-        final_molecule = molecule_dataset.get_record(molecule_name, optimization_level).get_final_molecule()
+        if len(molecule_dataset.get_record(molecule_name, optimization_level).get_initial_molecule().symbols) == 1:
+            final_molecule = molecule_dataset.get_record(molecule_name, optimization_level).get_initial_molecule()
+        else:
+            final_molecule = molecule_dataset.get_record(molecule_name, optimization_level).get_final_molecule()
     except KeyError:
         logger.info(f"{molecule_name} is not optimized at the requested level of theory, please optimize them first.")
         raise KeyError

--- a/workflows/launch_extract_be_data.py
+++ b/workflows/launch_extract_be_data.py
@@ -326,14 +326,22 @@ def zpve_correction(
 
         # Extracting ZPVE for the three molecules
         d, d_bol = get_zpve_mol(client, mol_list[0], lot_opt)
-        m1, _ = get_zpve_mol(client, mol_list[1], lot_opt, on_imaginary="raise")
+        m1, _ = get_zpve_mol(client, mol_list[1], lot_opt, on_imaginary="raise") 
         m2, _ = get_zpve_mol(client, mol_list[2], lot_opt, on_imaginary="raise")
 
-        if not (m1 and m2):
-            logger.info(
-                f"Molecules {mol_list[1]} and {mol_list[2]} have no Hessian. Compute them first."
-            )
-            raise IndexError
+        # Ignoring Hessian check if m2 is an atom 
+        if len(client.query_molecules(mol_list[2])[0].symbols) == 1:
+            if not (m1):
+                logger.info(
+                    f"Molecules {mol_list[1]} have no Hessian. Compute them first."
+                )
+                raise IndexError
+        else:
+            if not (m1 and m2):
+                logger.info(
+                    f"Molecules {mol_list[1]} and {mol_list[2]} have no Hessian. Compute them first."
+                )
+                raise IndexError
 
         if not d_bol:
             logger.info(f"Appending structure {entry} to the list for deletion.")

--- a/workflows/launch_sampling.py
+++ b/workflows/launch_sampling.py
@@ -438,10 +438,15 @@ def main():
     ds_wc = client.get_collection("OptimizationDataset", args.surface_model_collection)
 
     # Check if all the molecules are optimized at the requested level of theory
-    check_optimized_molecule(ds_sm, opt_lot, [smol_name])
-    check_optimized_molecule(ds_wc, opt_lot, ds_wc.data.records.keys())
+    # If cycle for atom exemption
+    if len(ds_sm.get_record(smol_name, opt_lot).get_initial_molecule().symbols) == 1:
+        check_optimized_molecule(ds_wc, opt_lot, ds_wc.data.records.keys())
+        args_dict["target_mol"] = ds_sm.get_record(smol_name, opt_lot).get_initial_molecule()
+    else:
+        check_optimized_molecule(ds_sm, opt_lot, [smol_name])
+        check_optimized_molecule(ds_wc, opt_lot, ds_wc.data.records.keys())
+        args_dict["target_mol"] = ds_sm.get_record(smol_name, opt_lot).get_final_molecule()
 
-    args_dict["target_mol"] = ds_sm.get_record(smol_name, opt_lot).get_final_molecule()
     args_dict["client"] = client
 
     count = 0


### PR DESCRIPTION
Exemptions have been added in order for the beep workflow to be compatible with **atoms**.
This changes where made for the **sampling**, be_hess **calculations** and the be_hess data **extraction**.
All of this was done by adding **special cases** for when the xyz file only had one atom in it. This is detected by using "_symbols_" from the **QCFractal** package (which displays all of the elements of a molecule in a list) and reading the length of said list.
if **len() == 1**, the exemptions where applied.
By doing it this way, the code will **not** take an empty xyz has an exemption and will give the expected error in said case.

Note: _"symbols" treats atoms of the same element as different units, i.e., molecules like H2 will return: ['H', 'H'], so it will not be treated as an atom._

### Detailed changes of each file

- binding_energy_compute.py: Code was added to the compute_hessian function so atoms are deleted from the list of molecules that need their hessian calculated
- launch_be_hess.py: An exemption as been added for atoms so the xyz that is being pulled is the initial_molecules structure (given that there is no final_molecule since they can not be optimized)
- launch_extract_be_data.py: Given that the hessian for the atom was never calculated, its given automatically a default value of 0.0, which the code took as if there is no hessian calculation. Therefore, an exemption has been added so if there is an atom, the check for the hessian calculation is skipped for it, but not for the water cluster
- launch_sampling.py: Same changes as in launch_be_hess.py