### PR TITLE
Release/0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `{"rmsd_eq": 1.0, "rmsd_force": 1.0}` (equal weighting of the two
   metrics that survive the geom-benchmark physical filter).
 
+### Fixed
+
+- `be_hess`: bypass Psi4's default ADIIS warmup by setting
+  `scf_initial_accelerator: NONE` in the SCF keywords. On Psi4 1.10
+  the ADIIS path triggered intermittent SCF convergence failures on a
+  fraction of BE records. Verified on H2O / B3LYP / def2-SVP that pure
+  DIIS reaches the same converged energy (Δ < 1e-13 Ha) without the
+  ADIIS markers in the Psi4 output. No effect on already-submitted
+  records — only new submissions pick up the override.
+
 ## [0.12.0] — 2026-05-30
 
 The first BEEP release in the qcportal 0.63+ era. The QCFractal stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`nm_sampling` workflow** — per-functional force-RMSE benchmark on
+  normal-mode-displaced geometries. For each binding site, BEEP
+  computes a cheap Hessian (default `hf/def2-svp`, configurable),
+  diagonalises it via Psi4/qcelemental, classifies every vibrational
+  mode as **intermolecular / bending / stretching** by
+  fragment-centre-of-mass projection, picks the lowest-frequency modes
+  in each band up to per-band caps (defaults `3 / 2 / 1`), and
+  generates ± displaced geometries at per-band RMS Cartesian
+  amplitudes (defaults `0.08 / 0.05 / 0.03 Å`). At every displacement
+  it submits a CCSD(T)/aug-cc-pvtz reference gradient plus a DFT
+  gradient per functional in the geom_benchmark pool, then reports
+  **per-Cartesian-component force RMSE** vs CCSD(T) grouped by
+  functional category. Same per-group log layout as the
+  `geom_benchmark` trajectory output. Invoke via `beep --config
+  nm_sampling.json`; `beep --schema nm_sampling` for the full config.
+
+  *Why force RMSE on displacements and not just along the trajectory.*
+  Trajectory sampling probes a one-dimensional path; normal-mode
+  displacements span the soft, chemically-relevant degrees of freedom
+  off equilibrium. R2SCAN-3c wins on the H2/W1 sanity benchmark at
+  18.5 meV/Å; HF-3c last at 805 meV/Å — both consistent with
+  expectation. Single-metric ranking (no z-score machinery) — the
+  per-group summary picks winners by raw RMSE.
+
 - **Trajectory analysis in `geom_benchmark`** (default-on). For each
   DFT functional, BEEP now submits SP + gradient calculations at every
   geometry along the reference optimization trajectory and reports the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to BEEP are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] — 0.13.0.dev
+
+### Added
+
+- **Trajectory analysis in `geom_benchmark`** (default-on). For each
+  DFT functional, BEEP now submits SP + gradient calculations at every
+  geometry along the reference optimization trajectory and reports the
+  per-Cartesian-component **RMSD of the force** (meV/Å) vs the
+  reference. Combined with the existing equilibrium-geometry RMSD via
+  a z-score-weighted ranking (weights configurable via
+  `score_weights`). Same per-group table layout as the existing
+  `BENCHMARK RESULTS` section; appears immediately below it in the
+  workflow log. Inspired by the MLP test-set validation in Bovolenta
+  et al. 2025 (A&A, in press; arXiv 2508.14219), Appendix C.2 /
+  Fig C.1 / Table C.1. Set `trajectory_analysis: false` in the
+  workflow config to keep the legacy eq-geometry-only behaviour.
+
+  *Why force RMSD and not energy MAE/RMSE.* Absolute total energies
+  carry method-specific offsets (correlation, basis, BSSE) that
+  dominate any cross-method comparison and aren't relevant to
+  geometry quality. Gradient deviations reflect PES shape, which is
+  what geometry optimization actually cares about. For relative-energy
+  comparison use the `energy_benchmark` workflow. RMSD (rather than
+  MAE) is used to penalise occasional large failures — a single bad
+  gradient step is exactly the failure mode that derails a real
+  geometry optimization.
+
+- **`combined_zscore_ranking` is weight-driven.** The metrics combined
+  are taken from `weights.keys()`, so the same function serves the
+  2-metric geom-benchmark case (`rmsd_eq` + `rmsd_force`) and any
+  future N-metric variant without modification.
+
+### Changed
+
+- `geom_benchmark` now performs additional SP + gradient submissions
+  per functional × reference-trajectory step when
+  `trajectory_analysis` is enabled (the new default). Existing 0.12.x
+  configs that don't set the field will pick up this behaviour
+  automatically; opt out with `trajectory_analysis: false`.
+
+- `GeomBenchmarkConfig.score_weights` now defaults to
+  `{"rmsd_eq": 1.0, "rmsd_force": 1.0}` (equal weighting of the two
+  metrics that survive the geom-benchmark physical filter).
+
 ## [0.12.0] — 2026-05-30
 
 The first BEEP release in the qcportal 0.63+ era. The QCFractal stack

--- a/beep/adapters/qcfractal_adapter.py
+++ b/beep/adapters/qcfractal_adapter.py
@@ -1445,6 +1445,74 @@ def fetch_sp_energy_gradient(
     return energy, grad
 
 
+def fetch_normal_modes(
+    client: PortalClient, mol, hessian_lot: str,
+) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[Molecule]]:
+    """Fetch the complete Hessian record for ``mol`` at ``hessian_lot`` and
+    run vibrational analysis. Returns ``(frequencies_cm, modes_cart, mol_obj)``
+    where modes are Cartesian, un-mass-weighted, and TR-projected.
+
+    Mirrors the Hessian-record query block in :func:`get_zpve_mol` but
+    returns the raw normal-mode data (frequencies + Cartesian eigenvectors)
+    instead of the ZPE summary.
+
+    Parameters
+    ----------
+    client : PortalClient
+    mol : int
+        Molecule ID on the server.
+    hessian_lot : str
+        Method + basis as ``method_basis`` (e.g. ``"hf_def2-svp"``).
+
+    Returns
+    -------
+    frequencies_cm : (n_vib,) complex ndarray, or None if no record
+    modes_cart : (n_vib, n_atoms, 3) ndarray, or None if no record
+    mol_obj : qcelemental Molecule (the one attached to the record), or None
+    """
+    from ..core.normal_mode_sampling import extract_normal_modes_from_hessian_record
+
+    logger = logging.getLogger("beep")
+    lot_parts = hessian_lot.split("_", 1)
+    method = lot_parts[0]
+    basis = lot_parts[1] if len(lot_parts) == 2 else None
+
+    results = list(client.query_singlepoints(
+        driver=SinglepointDriver.hessian,
+        molecule_id=mol,
+        method=method,
+        basis=basis,
+        status=RecordStatusEnum.complete,
+    ))
+    # Defensive (see get_zpve_mol for backstory): drop records with None
+    # properties — accessing return_result on those crashes.
+    results = [r for r in results if r.properties is not None]
+    if not results:
+        logger.info(
+            f"No complete hessian record at {method}/{basis} for molecule {mol}."
+        )
+        return None, None, None
+    if len(results) > 1:
+        logger.warning(
+            f"Found {len(results)} complete hessian records for molecule {mol} "
+            f"at {method}/{basis}; using the first."
+        )
+    record = results[0]
+    n_coords = 3 * len(record.molecule.symbols)
+    hess = np.asarray(record.return_result, dtype=float).reshape(n_coords, n_coords)
+
+    # Energy is optional — _vibanal_wfn uses it only for the thermo summary
+    qcvars = record.dict().get("extras", {}).get("qcvars", {})
+    energy = qcvars.get("CURRENT ENERGY")
+    if energy is None:
+        energy = (record.properties or {}).get("current energy") or 0.0
+
+    freqs_cm, modes_cart = extract_normal_modes_from_hessian_record(
+        hess=hess, molecule=record.molecule, energy=energy,
+    )
+    return freqs_cm, modes_cart, record.molecule
+
+
 def get_optimization_trajectory(
     odset: OptimizationDataset, entry_name: str, opt_lot: str,
 ) -> List[dict]:

--- a/beep/adapters/qcfractal_adapter.py
+++ b/beep/adapters/qcfractal_adapter.py
@@ -499,6 +499,54 @@ def submit_hessians(client: PortalClient, program: str, method: str,
     )
 
 
+def submit_gcp_corrections(client: PortalClient, mol_ids: list, tag: str):
+    """Submit gCP corrections at dft/def2-tzvp via the mctc-gcp program.
+
+    The gCP correction depends on the basis set and SCF type only, not on
+    the specific DFT functional, so one record per (molecule, basis) is
+    enough — the result is reused across every gcp-compatible functional
+    at extract time. We currently only target ``dft/def2-tzvp``; expand
+    here if BEEP adopts additional basis sets in the gCP-parametrised
+    range.
+    """
+    return client.add_singlepoints(
+        molecules=mol_ids,
+        program="mctc-gcp",
+        driver="energy",
+        method="dft/def2-tzvp",
+        basis=None,
+        keywords={},
+        compute_tag=tag,
+    )
+
+
+def fetch_gcp_corrections(
+    client: PortalClient, mol_ids: List[int],
+) -> Dict[int, float]:
+    """Fetch gCP correction energies (hartree) for the given molecule IDs.
+
+    Pairs with ``submit_gcp_corrections``. Returns ``{mol_id → gcp_energy}``
+    for records that are complete; molecules with missing/incomplete
+    records are silently omitted (caller should treat them as missing).
+    """
+    results = client.query_singlepoints(
+        program="mctc-gcp",
+        method="dft/def2-tzvp",
+        molecule_id=mol_ids,
+    )
+    out: Dict[int, float] = {}
+    for r in results:
+        if not is_complete(r.status):
+            continue
+        # mctc-gcp publishes the correction as ``return_result`` (plus a few
+        # human-readable aliases like ``"gcp correction energy"``); the
+        # ``return_energy`` key Psi4/QC backends use does not exist here.
+        e = r.return_result
+        if e is not None:
+            out[r.molecule_id] = float(e)
+    return out
+
+
 def add_reaction(client: PortalClient, rdset_base_name: str,
                  name: str, stoichiometry: dict) -> None:
     """Add reaction entries across stoichiometry-specific datasets.
@@ -788,12 +836,10 @@ def fetch_reaction_values(client: PortalClient, rdset_base_name: str,
 
     spec_names = [spec_name] if spec_name else ds.specification_names
     data = {}
+    skipped_integrated: List[str] = []
     for sname in spec_names:
         if "_" in sname and _has_dispersion_suffix(sname.split("_", 1)[0]):
-            logger.warning(
-                f"Skipping integrated dispersion spec '{sname}' in {ds_name} "
-                f"— BEEP expects the separated pair (bare DFT + bare dispersion)."
-            )
+            skipped_integrated.append(sname)
             continue
 
         col_label = sname.replace("_", "/")
@@ -808,6 +854,13 @@ def fetch_reaction_values(client: PortalClient, rdset_base_name: str,
                 )
         data[col_label] = energies
 
+    if skipped_integrated:
+        logger.warning(
+            f"  Skipped {len(skipped_integrated)} integrated-dispersion spec(s) "
+            f"in {ds_name} (BEEP expects separated bare-DFT + bare-dispersion). "
+            f"Re-submit via compute_be_dft_energies to surface these data."
+        )
+
     df = pd.DataFrame(data)
 
     # Sum bare-DFT + bare-dispersion into composite columns. A bare-dispersion
@@ -817,6 +870,7 @@ def fetch_reaction_values(client: PortalClient, rdset_base_name: str,
         c for c in df.columns
         if "/" not in c and any(c.endswith(suf) for suf in DISPERSION_SUFFIXES)
     ]
+    bare_dft_cols_consumed = set()
     for disp_col in disp_cols:
         for suffix in DISPERSION_SUFFIXES:
             if disp_col.endswith(suffix):
@@ -827,6 +881,15 @@ def fetch_reaction_values(client: PortalClient, rdset_base_name: str,
             basis_part = dft_col.split("/", 1)[1]
             composite_col = f"{disp_col}/{basis_part}"
             df[composite_col] = df[dft_col] + df[disp_col]
+            bare_dft_cols_consumed.add(dft_col)
+
+    # The bare-DFT and bare-dispersion columns are submission/summing
+    # artifacts; user-facing output (log tables, saved JSON) should only
+    # carry the composite or integrated columns. Drop them now so every
+    # downstream caller sees a clean DataFrame.
+    cols_to_drop = list(bare_dft_cols_consumed) + disp_cols
+    if cols_to_drop:
+        df = df.drop(columns=cols_to_drop, errors="ignore")
 
     return df
 
@@ -1024,6 +1087,10 @@ def compute_be_dft_energies(
     all_submitted = 0
     all_existing = 0
 
+    # Local import to avoid a circular module-load dependency between
+    # adapters and core/dft_functionals.
+    from ..core.dft_functionals import is_3c_method
+
     for i, lot in enumerate(all_dft):
         method, basis = lot.split("_")
         bare, disp_method, disp_program = _split_dispersion(method)
@@ -1031,8 +1098,13 @@ def compute_be_dft_energies(
 
         lot_submitted = 0
         lot_existing = 0
+        # -3c composites already include gCP in the SCF; computing the BSSE
+        # counterpoise stoich on top would double-correct.
+        skip_stoichs = {"bsse"} if is_3c_method(method) else set()
 
         for stoich in STOICH_TYPES:
+            if stoich in skip_stoichs:
+                continue
             if disp_method is None:
                 # No dispersion suffix — single integrated spec
                 result = submit_energies(

--- a/beep/adapters/qcfractal_adapter.py
+++ b/beep/adapters/qcfractal_adapter.py
@@ -27,8 +27,11 @@ from qcportal.record_models import RecordStatusEnum, PriorityEnum
 from qcportal.singlepoint.record_models import QCSpecification, SinglepointDriver
 from qcportal.optimization.record_models import OptimizationSpecification
 from qcportal.optimization.dataset_models import OptimizationDataset
-from qcportal.singlepoint.dataset_models import SinglepointDataset
+from qcportal.singlepoint.dataset_models import (
+    SinglepointDataset, SinglepointDatasetNewEntry,
+)
 from qcportal.reaction.dataset_models import ReactionDataset
+import numpy as np
 from qcportal.reaction.record_models import ReactionSpecification, ReactionKeywords
 from qcelemental.models.molecule import Molecule
 from pydantic import ValidationError
@@ -1278,3 +1281,124 @@ def get_zpve_mol(client: PortalClient, mol, lot_opt: str,
     return therm["ZPE_vib"].data, True
 
 
+# ---------------------------------------------------------------------------
+# Trajectory-benchmark singlepoint helpers (geom_benchmark trajectory mode)
+# ---------------------------------------------------------------------------
+
+def get_or_create_singlepoint_dataset(
+    client: PortalClient, name: str,
+) -> SinglepointDataset:
+    """Get-or-create a SinglepointDataset by name."""
+    return get_or_create_collection(
+        client, name, collection_type=SinglepointDataset,
+    )
+
+
+def add_gradient_spec(
+    ds_sp: SinglepointDataset,
+    spec_name: str,
+    method: str,
+    basis: Optional[str],
+    program: str = "psi4",
+    keywords: Optional[dict] = None,
+    description: str = "",
+) -> str:
+    """Add an SP + gradient ``QCSpecification`` to a ``SinglepointDataset``.
+
+    Idempotent: ``add_specification`` silently reports already-existing
+    specs. Returns the lowercased spec name actually registered.
+    """
+    qc_spec = QCSpecification(
+        program=program,
+        driver=SinglepointDriver.gradient,
+        method=method,
+        basis=basis,
+        keywords=keywords or {},
+    )
+    name = spec_name.lower()
+    ds_sp.add_specification(
+        name=name, specification=qc_spec, description=description,
+    )
+    return name
+
+
+def add_singlepoint_entries(
+    ds_sp: SinglepointDataset,
+    entries: List[Tuple[str, Molecule]],
+) -> Any:
+    """Bulk-add ``(entry_name, Molecule)`` pairs to a SinglepointDataset.
+
+    Faster than calling ``add_entry`` in a loop because the server is hit
+    once per batch.
+    """
+    new_entries = [
+        SinglepointDatasetNewEntry(name=name, molecule=mol)
+        for name, mol in entries
+    ]
+    return ds_sp.add_entries(new_entries)
+
+
+def submit_singlepoints_in_dataset(
+    ds_sp: SinglepointDataset,
+    spec_names: List[str],
+    tag: str,
+    subset=None,
+) -> Any:
+    """Submit SP computations from a SinglepointDataset for the given specs."""
+    entry_names = list(subset) if subset else None
+    return ds_sp.submit(
+        entry_names=entry_names,
+        specification_names=spec_names,
+        compute_tag=tag,
+    )
+
+
+def fetch_sp_energy_gradient(
+    ds_sp: SinglepointDataset, entry_name: str, spec_name: str,
+) -> Tuple[Optional[float], Optional[np.ndarray]]:
+    """Fetch ``(energy_hartree, gradient_hartree_per_bohr)`` from a record.
+
+    Gradient is reshaped from the flat list qcportal returns to
+    ``(n_atoms, 3)``. Returns ``(None, None)`` if the record is missing,
+    errored, or incomplete.
+    """
+    record = ds_sp.get_record(entry_name, spec_name.lower())
+    if record is None or not is_complete(record.status):
+        return None, None
+    props = record.properties or {}
+    energy = props.get("return_energy")
+    grad = props.get("return_gradient")
+    if grad is not None:
+        grad = np.asarray(grad, dtype=float).reshape(-1, 3)
+    return energy, grad
+
+
+def get_optimization_trajectory(
+    odset: OptimizationDataset, entry_name: str, opt_lot: str,
+) -> List[dict]:
+    """Pull every step of a completed optimization as a list of dicts.
+
+    Each dict has keys ``molecule`` (qcelemental Molecule),
+    ``energy_hartree`` (float or None) and ``gradient_hartree_per_bohr``
+    (np.ndarray of shape ``(n_atoms, 3)`` or None). Returns ``[]`` if
+    the opt is missing, errored, or has an empty trajectory.
+
+    Used by ``geom_benchmark`` trajectory analysis to obtain the shared
+    set of geometries (and reference E + ∇E) for cross-functional
+    comparison.
+    """
+    record = odset.get_record(entry_name, opt_lot.lower())
+    if record is None or not is_complete(record.status):
+        return []
+    steps = []
+    for sp in record.trajectory or []:
+        props = sp.properties or {}
+        grad = props.get("return_gradient")
+        if grad is not None:
+            grad = np.asarray(grad, dtype=float).reshape(-1, 3)
+        steps.append({
+            "molecule": sp.molecule,
+            "energy_hartree": props.get("return_energy"),
+            "gradient_hartree_per_bohr": grad,
+        })
+    return steps

--- a/beep/cli.py
+++ b/beep/cli.py
@@ -7,7 +7,8 @@ Usage:
     beep --schema sampling
 
 The JSON file must contain a "workflow" key that selects which workflow to run.
-Valid workflow values: sampling, be_hess, extract, pre_exp, geom_benchmark, energy_benchmark
+Valid workflow values: sampling, be_hess, extract, pre_exp, geom_benchmark,
+energy_benchmark, nm_sampling
 """
 import argparse
 import json
@@ -22,6 +23,7 @@ from .models import (
     PreExpConfig,
     GeomBenchmarkConfig,
     EnergyBenchmarkConfig,
+    NmSamplingConfig,
 )
 from .adapters.qcfractal_adapter import connect
 
@@ -32,6 +34,7 @@ WORKFLOW_MODELS = {
     "pre_exp": PreExpConfig,
     "geom_benchmark": GeomBenchmarkConfig,
     "energy_benchmark": EnergyBenchmarkConfig,
+    "nm_sampling": NmSamplingConfig,
 }
 
 
@@ -154,6 +157,8 @@ def main():
         from .workflows.geom_benchmark import run
     elif workflow == "energy_benchmark":
         from .workflows.energy_benchmark import run
+    elif workflow == "nm_sampling":
+        from .workflows.nm_sampling import run
 
     run(config, client)
 

--- a/beep/core/dft_functionals.py
+++ b/beep/core/dft_functionals.py
@@ -84,8 +84,6 @@ def hybrid_gga():
         'PBE0-NL',
         'B3PW91-NL',
         'REVPBE0-NL',
-        'PBEH3C',
-        'B97-D',
         'HF-D3BJ',
         # D4
         'B3LYP-D4',
@@ -212,3 +210,73 @@ def geom_sqm_mb():
         "R2SCAN-3c_def2-mTZVPP",
         "WB97X-3c_vDZP",
     ]
+
+
+def non_local():
+    """Functionals with non-local (NL / VV10) dispersion treatment.
+
+    Cross-cuts the other categories: every entry here also lives in one
+    of ``gga`` / ``meta_gga`` / ``hybrid_gga`` / ``meta_hybrid_gga`` /
+    ``lrc``. The per-group log helpers walk every group dict, so a
+    functional with NL dispersion appears both in its structural class
+    table and in the Non-local table.
+    """
+    return [
+        # VV10 (atom-pairwise integrand on the density)
+        'B97M-V',         # also meta_gga
+        'WB97M-V',        # also meta_hybrid_gga
+        'WB97X-V',        # also lrc
+        'LC-VV10',        # also lrc
+        # -NL post-hoc non-local
+        'B3LYP-NL',       # also hybrid_gga
+        'PBE0-NL',        # also hybrid_gga
+        'B3PW91-NL',      # also hybrid_gga
+        'REVPBE0-NL',     # also hybrid_gga
+    ]
+
+
+# ---------------------------------------------------------------------------
+# gCP applicability
+#
+# The geometric counterpoise correction (Kruse & Grimme, JCP 136, 154101
+# (2012)) is parametrized for specific (SCF-type, basis) combinations only.
+# For BEEP's energy_benchmark workflow we restrict gCP to the single
+# (DFT, def2-tzvp) target, which keeps the workflow neat and lean and
+# covers the production use case.
+# ---------------------------------------------------------------------------
+
+_THREE_C_METHODS = {
+    "HF3C", "HF-3C",
+    "PBEH3C", "PBEH-3C",
+    "B97-3C", "B973C",
+    "R2SCAN-3C", "R2SCAN3C",
+    "WB97X-3C", "WB97X3C",
+}
+
+
+def is_3c_method(name: str) -> bool:
+    """True if ``name`` is a -3c composite (gCP already baked in).
+
+    Used to skip BSSE/CP-fragment submissions for these methods —
+    counterpoise on top of an already-gCP-corrected SCF double-corrects.
+    """
+    if not name:
+        return False
+    return name.upper() in _THREE_C_METHODS
+
+
+def gcp_compatible_functionals():
+    """Functionals that get an explicit gCP correction when the user
+    enables ``gcp_correction`` in the energy_benchmark workflow.
+
+    Concatenation of the standard semi-local lists, excluding:
+      - -3c composites (gCP is already part of the method)
+      - Double hybrids (gCP is not parametrized for the MP2-correlated
+        regime; published parameters fit semi-local functionals only)
+      - HF-D3BJ (gCP for HF needs the ``hf/def2-tzvp`` parameter set, a
+        separate code path we don't support — bare HF + dispersion is
+        a niche entry rather than a production binding-energy method)
+    """
+    excluded = {"HF-D3BJ"}
+    pool = [*gga(), *meta_gga(), *hybrid_gga(), *meta_hybrid_gga(), *lrc()]
+    return [m for m in pool if m.upper() not in excluded and not is_3c_method(m)]

--- a/beep/core/logging_utils.py
+++ b/beep/core/logging_utils.py
@@ -403,6 +403,90 @@ def _strip_group_prefix(name: str) -> str:
     return name
 
 
+def log_energy_mae_per_group(
+    logger: logging.Logger,
+    df_ae: pd.DataFrame,
+    dft_func_dict: dict,
+) -> None:
+    """Per-category MAE breakdown for the energy_benchmark output.
+
+    Mirrors ``log_trajectory_metrics_per_group``: one table per
+    functional category (GGA, Meta-GGA, Hybrid, Meta-Hybrid, LRC,
+    Non-local, …) listing the methods present in ``df_ae`` whose
+    column name matches a member of that category, sorted ascending by
+    MAE, with ``*`` next to the winner. A summary table at the bottom
+    lists the per-group winner.
+
+    Functionals may belong to **multiple** categories (e.g. ``B97M-V``
+    is both Meta-GGA and Non-local); those columns appear in every
+    matching category table.
+
+    Categories with no surviving columns (because every functional in
+    that list was filtered out by the integrated-dispersion convention)
+    are silently skipped.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Active BEEP logger.
+    df_ae : pd.DataFrame
+        Absolute-error DataFrame (entries × method/basis columns), as
+        produced by ``get_errors_dataframe``.
+    dft_func_dict : dict
+        ``{group_display_name → [functional_name, ...]}`` mapping. The
+        functional names are matched case-insensitively against the
+        bare-method portion of each column (``col.rsplit("/", 1)[0]``).
+    """
+    if df_ae.empty:
+        logger.warning("\n  No MAE data to display.\n")
+        return
+
+    # MAE per column = mean of |signed error|. Despite the "_ae" suffix in
+    # the caller's variable name, the DataFrame from get_errors_dataframe is
+    # signed (E_dft − E_ref); take abs() before averaging — same convention
+    # as the legacy ``log_energy_mae``.
+    mae = df_ae.abs().mean(axis=0)
+    name_width = 30
+    summary = {}   # group_display -> (winner, winner_mae)
+
+    for group, funcs in dft_func_dict.items():
+        funcs_lower = {f.lower() for f in funcs}
+        in_group_cols = [
+            c for c in df_ae.columns
+            if c.rsplit("/", 1)[0] in funcs_lower
+        ]
+        if not in_group_cols:
+            continue
+
+        group_maes = mae[in_group_cols].sort_values()
+        winner = str(group_maes.idxmin())
+        winner_mae = float(group_maes.iloc[0])
+        summary[group] = (winner, winner_mae)
+
+        logger.info(f"\nFunctional Group: {group}")
+        header = f"{'Level of Theory':<{name_width}} | MAE"
+        logger.info(header)
+        logger.info("-" * max(len(header), name_width + 14))
+        for col, val in group_maes.items():
+            mark = "*" if col == winner else " "
+            logger.info(f"{col:<{name_width}} | {val:.6f} {mark}")
+
+    if not summary:
+        return
+
+    logger.info("\nSummary of best functional per group (lowest MAE):")
+    summary_header = (
+        f"{'Functional Group':<{name_width}} | "
+        f"{'Level of Theory':<{name_width}} | {'MAE':<12}"
+    )
+    logger.info(summary_header)
+    logger.info("-" * len(summary_header))
+    for group, (winner, val) in summary.items():
+        logger.info(
+            f"{group:<{name_width}} | {winner:<{name_width}} | {val:.6f}"
+        )
+
+
 def log_trajectory_metrics_per_group(
     logger: logging.Logger,
     traj_metrics: dict,

--- a/beep/core/logging_utils.py
+++ b/beep/core/logging_utils.py
@@ -391,3 +391,188 @@ def write_energy_log(df: pd.DataFrame, mol: str, existing_content: str = "", com
     content += f"{'   '.join(std_values):<50}"
     content += "\n"
     return content
+
+
+def _strip_group_prefix(name: str) -> str:
+    """Drop the 'geom_' / 'energy_' style prefix from functional-group names
+    so that they match the display style used by ``log_dataframe_averages``
+    (e.g. ``geom_hmgga_dz`` → ``hmgga_dz``)."""
+    for prefix in ("geom_", "energy_"):
+        if name.startswith(prefix):
+            return name[len(prefix):]
+    return name
+
+
+def log_trajectory_metrics_per_group(
+    logger: logging.Logger,
+    traj_metrics: dict,
+    dft_geom_functionals: dict,
+    ranking_df: pd.DataFrame = None,
+) -> None:
+    """Per-group trajectory force-RMSD table, BENCHMARK RESULTS style.
+
+    For each functional group, prints the per-Cartesian-component force
+    RMSD (meV/Å) vs reference. The row with the best (lowest) combined
+    score in the group is marked with ``*``; falls back to best
+    ``rmsd_force`` when no ``ranking_df`` is supplied. A summary table
+    lists the per-group winner at the bottom.
+
+    Energy is not displayed — absolute energies aren't meaningful for
+    geometry benchmarking (use the energy_benchmark workflow for
+    relative-energy comparison).
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Active BEEP logger.
+    traj_metrics : dict
+        ``{lowercase_functional → {rmsd_energy, rmsd_force, ...}}``.
+    dft_geom_functionals : dict
+        ``{group_name → [mixed_case_functional, ...]}`` mapping. The
+        group display name has any ``geom_`` / ``energy_`` prefix
+        stripped to match ``log_dataframe_averages``.
+    ranking_df : pd.DataFrame, optional
+        Output of ``combined_zscore_ranking``; if provided, the
+        per-group winner is chosen by ``combined_score``.
+    """
+    if not traj_metrics:
+        logger.warning("\n  No trajectory metrics to display.\n")
+        return
+
+    name_width = 30
+    metric_header = "RMSD_F (meV/Å)"
+    summary = {}   # display_group -> (winner_mixed_case, best_metric_value)
+
+    for group, funcs in dft_geom_functionals.items():
+        group_display = _strip_group_prefix(group)
+        in_group = [f for f in funcs if f.lower() in traj_metrics]
+        if not in_group:
+            continue
+
+        if ranking_df is not None:
+            ranked = [f for f in in_group if f.lower() in ranking_df.index]
+            if ranked:
+                lower_to_orig = {f.lower(): f for f in ranked}
+                best_lc = ranking_df.loc[
+                    list(lower_to_orig), "combined_score"
+                ].idxmin()
+                best_func = lower_to_orig[best_lc]
+                summary[group_display] = (
+                    best_func, ranking_df.at[best_lc, "combined_score"],
+                )
+            else:
+                best_func = None
+        else:
+            best_func = min(
+                in_group, key=lambda f: traj_metrics[f.lower()]["rmsd_force"],
+            )
+            summary[group_display] = (
+                best_func, traj_metrics[best_func.lower()]["rmsd_force"],
+            )
+
+        logger.info(f"\nFunctional Group: {group_display}")
+        header = f"{'Level of Theory':<{name_width}} | {metric_header}"
+        logger.info(header)
+        logger.info("-" * max(len(header), name_width + 18))
+        for func in in_group:
+            v = traj_metrics[func.lower()]["rmsd_force"]
+            mark = "*" if func == best_func else " "
+            logger.info(f"{func:<{name_width}} | {v:<14.4f} {mark}")
+
+    if not summary:
+        return
+    if ranking_df is not None:
+        title = "Summary of best functional per group (by combined score):"
+        score_header = "Combined Score"
+        fmt = "{:<+14.4f}"
+    else:
+        title = "Summary of best functional per group (by RMSD_F):"
+        score_header = "RMSD_F (meV/Å)"
+        fmt = "{:<14.4f}"
+
+    logger.info(f"\n{title}")
+    summary_header = (
+        f"{'Functional Group':<{name_width}} | "
+        f"{'Level of Theory':<{name_width}} | {score_header:<14}"
+    )
+    logger.info(summary_header)
+    logger.info("-" * len(summary_header))
+    for group, (winner, score) in summary.items():
+        logger.info(
+            f"{group:<{name_width}} | {winner:<{name_width}} | "
+            + fmt.format(score)
+        )
+
+
+def log_trajectory_ranking_table(
+    logger: logging.Logger,
+    ranking_df: pd.DataFrame,
+    score_weights: dict = None,
+) -> None:
+    """Combined z-score-weighted ranking with an inline methodology block.
+
+    Explains the score formula in the log itself so anyone reading the
+    log can audit the ranking without having to dig into the source.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Active BEEP logger.
+    ranking_df : pd.DataFrame
+        Output of ``combined_zscore_ranking``; rows are functionals
+        (lowercase), columns include raw metrics + z-scores +
+        ``combined_score``.
+    score_weights : dict, optional
+        ``{rmsd_eq, rmsd_force}`` weights to display in the methodology
+        block. Defaults to equal weights when omitted.
+    """
+    if ranking_df is None or ranking_df.empty:
+        logger.warning(
+            "\n  Combined ranking unavailable "
+            "(no functionals with complete data on both metrics).\n"
+        )
+        return
+    methods = list(ranking_df.index)
+    width = max(36, max(len(m) for m in methods) + 2)
+    cols = [
+        "rmsd_eq", "rmsd_force",
+        "z_rmsd_eq", "z_rmsd_force", "combined_score",
+    ]
+    headers = [
+        "RMSD_eq", "RMSD_F",
+        "z(RMSD_eq)", "z(RMSD_F)", "Score",
+    ]
+
+    w = score_weights or {"rmsd_eq": 1.0, "rmsd_force": 1.0}
+    logger.info("")
+    logger.info("  Methodology")
+    logger.info("    Two metrics — RMSD_eq (equilibrium-geometry deviation,")
+    logger.info("    Å) and RMSD_F (per-Cartesian-component force deviation")
+    logger.info("    along the reference trajectory, meV/Å) — have different")
+    logger.info("    units. To combine them we convert each to a z-score")
+    logger.info("    across the benchmarked functionals:")
+    logger.info("        z_m = (value_m - mean) / std         (population std, ddof=0)")
+    logger.info("    The combined score is a weighted sum of the z-scores:")
+    logger.info("        score = w_R · z(RMSD_eq) + w_F · z(RMSD_F)")
+    logger.info(
+        f"    Current weights: w_R = {w.get('rmsd_eq', 1.0)}, "
+        f"w_F = {w.get('rmsd_force', 1.0)}"
+    )
+    logger.info("    (override via 'score_weights' in the workflow config.)")
+    logger.info("    Z-scores are dimensionless: this puts the two metrics")
+    logger.info("    on a common scale without arbitrary unit conversions.")
+    logger.info("    Lower combined score = better.")
+    logger.info("")
+    logger.info("    Absolute energies are not part of the score — they're")
+    logger.info("    dominated by total-energy-scale differences (correlation,")
+    logger.info("    basis, BSSE) rather than PES quality. Use the")
+    logger.info("    energy_benchmark workflow for relative-energy comparison.")
+    logger.info("")
+    header = f"  {'Functional':<{width}s}" + "".join(f"{h:<14s}" for h in headers)
+    logger.info(header)
+    logger.info("  " + "-" * (len(header) - 2))
+    for m in methods:
+        line = f"  {m:<{width}s}"
+        for col in cols:
+            line += f"{ranking_df.at[m, col]:<+14.4f}"
+        logger.info(line)

--- a/beep/core/logging_utils.py
+++ b/beep/core/logging_utils.py
@@ -588,6 +588,15 @@ def log_trajectory_metrics_per_group(
         )
 
 
+# Per-metric display metadata used by log_trajectory_ranking_table.
+# Maps metric column name → (short header, long description with units).
+# Add entries here when a new ranking metric is introduced.
+_RANKING_METRIC_META = {
+    "rmsd_eq":    ("RMSD_eq", "equilibrium-geometry deviation, Å"),
+    "rmsd_force": ("RMSD_F",  "per-Cartesian-component force RMSE, meV/Å"),
+}
+
+
 def log_trajectory_ranking_table(
     logger: logging.Logger,
     ranking_df: pd.DataFrame,
@@ -598,53 +607,71 @@ def log_trajectory_ranking_table(
     Explains the score formula in the log itself so anyone reading the
     log can audit the ranking without having to dig into the source.
 
+    Generic over any number of metrics — the columns displayed are
+    derived from ``score_weights.keys()`` so the same helper serves the
+    geom-trajectory case (2 metrics) and the nm-sampling case (1 metric).
+
     Parameters
     ----------
     logger : logging.Logger
         Active BEEP logger.
     ranking_df : pd.DataFrame
         Output of ``combined_zscore_ranking``; rows are functionals
-        (lowercase), columns include raw metrics + z-scores +
-        ``combined_score``.
+        (lowercase), columns include the raw metrics, their z-scores
+        (``z_<metric>``), and ``combined_score``.
     score_weights : dict, optional
-        ``{rmsd_eq, rmsd_force}`` weights to display in the methodology
-        block. Defaults to equal weights when omitted.
+        ``{metric_name → weight}``. Determines which columns are
+        displayed and the methodology block. Defaults to equal weights
+        on (``rmsd_eq``, ``rmsd_force``).
     """
     if ranking_df is None or ranking_df.empty:
         logger.warning(
             "\n  Combined ranking unavailable "
-            "(no functionals with complete data on both metrics).\n"
+            "(no functionals with complete data).\n"
         )
         return
-    methods = list(ranking_df.index)
-    width = max(36, max(len(m) for m in methods) + 2)
-    cols = [
-        "rmsd_eq", "rmsd_force",
-        "z_rmsd_eq", "z_rmsd_force", "combined_score",
-    ]
-    headers = [
-        "RMSD_eq", "RMSD_F",
-        "z(RMSD_eq)", "z(RMSD_F)", "Score",
-    ]
 
     w = score_weights or {"rmsd_eq": 1.0, "rmsd_force": 1.0}
+    metric_names = list(w.keys())
+    raw_headers = [_RANKING_METRIC_META.get(m, (m, m))[0] for m in metric_names]
+    cols = list(metric_names) + [f"z_{m}" for m in metric_names] + ["combined_score"]
+    headers = (
+        raw_headers
+        + [f"z({h})" for h in raw_headers]
+        + ["Score"]
+    )
+
+    methods = list(ranking_df.index)
+    width = max(36, max(len(m) for m in methods) + 2)
+
     logger.info("")
     logger.info("  Methodology")
-    logger.info("    Two metrics — RMSD_eq (equilibrium-geometry deviation,")
-    logger.info("    Å) and RMSD_F (per-Cartesian-component force deviation")
-    logger.info("    along the reference trajectory, meV/Å) — have different")
-    logger.info("    units. To combine them we convert each to a z-score")
-    logger.info("    across the benchmarked functionals:")
+    if len(metric_names) == 1:
+        m = metric_names[0]
+        h, desc = _RANKING_METRIC_META.get(m, (m, m))
+        logger.info(f"    One metric — {h} ({desc}) — converted to a")
+        logger.info("    z-score across the benchmarked functionals:")
+    else:
+        descs = ", ".join(
+            f"{_RANKING_METRIC_META.get(m, (m, m))[0]} ({_RANKING_METRIC_META.get(m, (m, m))[1]})"
+            for m in metric_names
+        )
+        logger.info(
+            f"    {len(metric_names)} metrics — {descs} — have different"
+        )
+        logger.info("    units. To combine them we convert each to a z-score")
+        logger.info("    across the benchmarked functionals:")
     logger.info("        z_m = (value_m - mean) / std         (population std, ddof=0)")
     logger.info("    The combined score is a weighted sum of the z-scores:")
-    logger.info("        score = w_R · z(RMSD_eq) + w_F · z(RMSD_F)")
-    logger.info(
-        f"    Current weights: w_R = {w.get('rmsd_eq', 1.0)}, "
-        f"w_F = {w.get('rmsd_force', 1.0)}"
+    formula = " + ".join(f"w_{h} · z({h})" for h in raw_headers)
+    logger.info(f"        score = {formula}")
+    weights_line = ", ".join(
+        f"w_{h} = {w[m]}" for m, h in zip(metric_names, raw_headers)
     )
+    logger.info(f"    Current weights: {weights_line}")
     logger.info("    (override via 'score_weights' in the workflow config.)")
-    logger.info("    Z-scores are dimensionless: this puts the two metrics")
-    logger.info("    on a common scale without arbitrary unit conversions.")
+    logger.info("    Z-scores are dimensionless: this puts the metrics on a")
+    logger.info("    common scale without arbitrary unit conversions.")
     logger.info("    Lower combined score = better.")
     logger.info("")
     logger.info("    Absolute energies are not part of the score — they're")

--- a/beep/core/nm_sampling_workflow.py
+++ b/beep/core/nm_sampling_workflow.py
@@ -1,0 +1,620 @@
+"""Normal-mode sampling benchmark orchestration helpers.
+
+Workflow-level glue for the ``nm_sampling`` workflow: per binding site,
+compute a Hessian → diagonalise → classify normal modes via fragment-COM
+projection → pick lowest-frequency modes per band → generate ± displaced
+geometries → submit CCSD(T) gradients (reference) plus DFT gradients per
+functional on every displacement → report per-functional force-RMSD vs
+CCSD(T), per-category.
+
+The pure-math layer lives in :mod:`beep.core.normal_mode_sampling`
+(classify/select/displace + the qcelemental harmonic-analysis wrapper);
+the QCFractal I/O lives in :mod:`beep.adapters.qcfractal_adapter`. This
+module chains them.
+
+The output format mirrors the trajectory-benchmark blueprint
+(:mod:`beep.core.trajectory_workflow`): per-system ``SinglepointDataset``
+named ``<system>_nmsamp``, entries ``disp_NNN`` per displaced structure,
+one gradient spec per functional plus a reference-CCSD(T) spec. The
+per-category MAE / force-RMSD reporting reuses
+``log_trajectory_metrics_per_group``.
+"""
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+try:
+    from qcelemental.models import Molecule
+except ImportError:  # pragma: no cover
+    from qcelemental.models.molecule import Molecule
+
+from ..adapters import qcfractal_adapter as qcf
+from ..adapters.qcfractal_adapter import is_complete, is_incomplete, is_error
+from .logging_utils import padded_log, log_trajectory_metrics_per_group
+from .normal_mode_sampling import (
+    classify_mode, select_modes, displace_along_mode,
+)
+from .trajectory_metrics import per_step_deltas, summarize_method_metrics
+
+bcheck = "✔"
+gear = "⚙"
+
+# Reference spec key. Set to the lowercased reference_grad_lot at run time;
+# the orchestrator stitches the value through so the per-method fetch can
+# pair the DFT result with the matching reference.
+_REF_SPEC_NAME = None
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — collect optimized geometries
+# ---------------------------------------------------------------------------
+
+def collect_optimized_geometries(
+    odset_dict: dict, geometry_opt_lot: str, logger: logging.Logger,
+) -> Dict[str, Molecule]:
+    """Pull each system's binding-site optimised geometry as a Molecule."""
+    out: Dict[str, Molecule] = {}
+    for struct_name, odset in odset_dict.items():
+        try:
+            record = odset.get_record(struct_name, geometry_opt_lot.lower())
+        except Exception as exc:
+            logger.warning(
+                f"  !! WARNING: {struct_name}: failed to fetch optimised "
+                f"geometry record ({type(exc).__name__}: {exc}) — skipping."
+            )
+            continue
+        if record is None or not is_complete(record.status):
+            logger.warning(
+                f"  {struct_name}: no complete optimisation at "
+                f"{geometry_opt_lot} — skipping."
+            )
+            continue
+        out[struct_name] = record.final_molecule
+        logger.info(
+            f"  {struct_name}: equilibrium geometry fetched "
+            f"({len(record.final_molecule.symbols)} atoms)."
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — submit Hessians
+# ---------------------------------------------------------------------------
+
+def submit_system_hessians(
+    client, ref_mols: Dict[str, Molecule],
+    hessian_lot: str, hessian_program: str,
+    hessian_keywords, tag_hessian: str,
+    logger: logging.Logger,
+) -> List[int]:
+    """Submit a Hessian SP for each system's equilibrium molecule."""
+    lot_parts = hessian_lot.split("_", 1)
+    method = lot_parts[0]
+    basis = lot_parts[1] if len(lot_parts) == 2 else None
+
+    mol_ids = [m.id for m in ref_mols.values() if m.id is not None]
+    if not mol_ids:
+        logger.warning("  No molecule IDs to submit Hessians for.")
+        return []
+
+    meta, record_ids = qcf.submit_hessians(
+        client=client, program=hessian_program,
+        method=method, basis=basis,
+        mol_ids=mol_ids, keywords=hessian_keywords or {},
+        tag=tag_hessian,
+    )
+    logger.info(
+        f"  Submitted {meta.n_inserted} new Hessian(s) at {method}/{basis} "
+        f"({meta.n_existing} already existed) to tag '{tag_hessian}'."
+    )
+    return record_ids
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — fetch + classify normal modes
+# ---------------------------------------------------------------------------
+
+def collect_system_normal_modes(
+    client, ref_mols: Dict[str, Molecule], hessian_lot: str,
+    n_adsorbate_atoms: int, inter_threshold: float, bend_max_cm: float,
+    logger: logging.Logger,
+) -> Dict[str, dict]:
+    """Per system, fetch the Hessian record and classify each normal mode.
+
+    Returns ``{struct_name → {frequencies_cm, modes_cart, classes, mol}}``.
+    Systems with missing Hessians are skipped.
+    """
+    out: Dict[str, dict] = {}
+    for struct_name, mol in ref_mols.items():
+        if mol.id is None:
+            logger.warning(
+                f"  {struct_name}: molecule has no server ID — skipping "
+                "normal-mode fetch."
+            )
+            continue
+        try:
+            freqs_cm, modes_cart, mol_from_record = qcf.fetch_normal_modes(
+                client, mol.id, hessian_lot,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"  !! WARNING: {struct_name}: failed to fetch normal modes "
+                f"({type(exc).__name__}: {exc}) — skipping."
+            )
+            continue
+        if freqs_cm is None or modes_cart is None or len(freqs_cm) == 0:
+            logger.warning(
+                f"  {struct_name}: no normal-mode data — skipping."
+            )
+            continue
+
+        masses = np.asarray(mol_from_record.masses)
+        classes = []
+        for i, freq in enumerate(freqs_cm):
+            cls = classify_mode(
+                mode_cart=modes_cart[i],
+                masses=masses,
+                n_adsorbate_atoms=n_adsorbate_atoms,
+                frequency_cm=float(np.real(freq)),
+                inter_threshold=inter_threshold,
+                bend_max_cm=bend_max_cm,
+            )
+            classes.append(cls)
+
+        # Count classes for the log line
+        counts = {b: classes.count(b) for b in ("intermolecular", "bending", "stretching")}
+        logger.info(
+            f"  {struct_name}: {len(freqs_cm)} vib modes — "
+            f"intermolecular={counts['intermolecular']}, "
+            f"bending={counts['bending']}, "
+            f"stretching={counts['stretching']}"
+        )
+
+        out[struct_name] = {
+            "frequencies_cm": freqs_cm,
+            "modes_cart": modes_cart,
+            "classes": classes,
+            "mol": mol_from_record,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — select displacements + build displaced molecules
+# ---------------------------------------------------------------------------
+
+def build_displaced_molecules(
+    mode_data: Dict[str, dict], bands: Dict[str, "dict"],
+    freq_max_imag_cm: float,
+    extra_amplitudes_lowest_count: int, extra_amplitude_factor: float,
+    logger: logging.Logger,
+) -> Dict[str, List[Tuple[str, Molecule, dict]]]:
+    """Per system, apply the per-band caps and generate ± displaced Molecules.
+
+    Returns ``{struct_name → [(entry_name, Molecule, metadata), ...]}`` where
+    ``metadata`` records the (mode_index, amplitude_A, sign, band, frequency_cm)
+    of each displacement for downstream logging.
+    """
+    band_caps = {b: spec.cap for b, spec in bands.items()}
+    band_amps = {b: spec.amplitude_A for b, spec in bands.items()}
+
+    out: Dict[str, List[Tuple[str, Molecule, dict]]] = {}
+    for struct_name, data in mode_data.items():
+        freqs = data["frequencies_cm"]
+        modes = data["modes_cart"]
+        classes = data["classes"]
+        mol = data["mol"]
+
+        picks = select_modes(
+            frequencies_cm=freqs, classes=classes,
+            band_caps=band_caps, band_amplitudes=band_amps,
+            freq_max_imag_cm=freq_max_imag_cm,
+            extra_amplitudes_lowest_count=extra_amplitudes_lowest_count,
+            extra_amplitude_factor=extra_amplitude_factor,
+        )
+        if not picks:
+            logger.warning(
+                f"  {struct_name}: no modes survived selection — skipping."
+            )
+            continue
+
+        geom_bohr = np.asarray(mol.geometry).reshape(-1, 3)
+        entries: List[Tuple[str, Molecule, dict]] = []
+        counter = 0
+        for mode_idx, amp_A, band in picks:
+            for sign in (+1, -1):
+                new_geom = displace_along_mode(
+                    geometry_bohr=geom_bohr,
+                    mode_cart=modes[mode_idx],
+                    amplitude_A=amp_A,
+                    sign=sign,
+                )
+                disp_mol = Molecule(
+                    symbols=mol.symbols,
+                    geometry=new_geom.flatten(),
+                    masses=mol.masses,
+                    molecular_charge=mol.molecular_charge,
+                    molecular_multiplicity=mol.molecular_multiplicity,
+                    fix_com=True, fix_orientation=True,
+                )
+                entry_name = f"disp_{counter:03d}"
+                entries.append((
+                    entry_name, disp_mol,
+                    {
+                        "mode_idx": int(mode_idx),
+                        "amplitude_A": float(amp_A),
+                        "sign": int(sign),
+                        "band": band,
+                        "frequency_cm": float(np.real(freqs[mode_idx])),
+                    },
+                ))
+                counter += 1
+        logger.info(
+            f"  {struct_name}: {len(picks)} mode picks → "
+            f"{len(entries)} displaced structures"
+        )
+        out[struct_name] = entries
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — build per-system SinglepointDatasets
+# ---------------------------------------------------------------------------
+
+def build_nm_sp_datasets(
+    client, displaced: Dict[str, List[Tuple[str, Molecule, dict]]],
+    all_dft_functionals: List[str], reference_spec_name: str,
+    reference_grad_lot: str, reference_grad_program: str,
+    reference_grad_keywords, dft_program: str, dft_keyword,
+    logger: logging.Logger,
+):
+    """Per system, create the `<system>_nmsamp` SinglepointDataset, add
+    entries, register one gradient spec per DFT functional + one reference
+    CCSD(T) spec. Idempotent."""
+    sp_dsets: Dict[str, object] = {}
+    dft_kw = dft_keyword if isinstance(dft_keyword, dict) else {}
+    ref_kw = reference_grad_keywords if isinstance(reference_grad_keywords, dict) else {}
+
+    ref_method, _, ref_basis = reference_grad_lot.partition("_")
+    if not ref_basis:
+        ref_basis = None
+
+    for struct_name, entries in displaced.items():
+        ds_name = f"{struct_name}_nmsamp"
+        ds_sp = qcf.get_or_create_singlepoint_dataset(client, ds_name)
+
+        qcf.add_singlepoint_entries(
+            ds_sp, [(name, mol) for name, mol, _meta in entries],
+        )
+
+        # DFT specs
+        for functional in all_dft_functionals:
+            method, basis = functional.split("_", 1)
+            qcf.add_gradient_spec(
+                ds_sp, spec_name=functional, method=method, basis=basis,
+                program=dft_program, keywords=dft_kw,
+                description=(
+                    f"NM displacement gradient at {functional} for "
+                    f"{struct_name}"
+                ),
+            )
+
+        # Reference CCSD(T) spec
+        qcf.add_gradient_spec(
+            ds_sp, spec_name=reference_spec_name,
+            method=ref_method, basis=ref_basis,
+            program=reference_grad_program, keywords=ref_kw,
+            description=f"NM displacement reference gradient at {reference_grad_lot}",
+        )
+
+        sp_dsets[struct_name] = ds_sp
+        logger.info(
+            f"  {struct_name}: dataset '{ds_name}' "
+            f"({len(entries)} entries, {len(all_dft_functionals)} DFT specs "
+            f"+ 1 reference spec)"
+        )
+    return sp_dsets
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — submit gradient SPs
+# ---------------------------------------------------------------------------
+
+def submit_nm_singlepoints(
+    sp_dsets: dict, all_dft_functionals: List[str], reference_spec_name: str,
+    tag_dft_grad: str, tag_reference_grad: str,
+    logger: logging.Logger,
+):
+    """Submit DFT specs to the DFT tag and the reference spec to the
+    reference tag. Returns counts for logging."""
+    inserted_dft = existing_dft = 0
+    inserted_ref = existing_ref = 0
+    for ds_sp in sp_dsets.values():
+        meta_dft = qcf.submit_singlepoints_in_dataset(
+            ds_sp, spec_names=all_dft_functionals, tag=tag_dft_grad,
+        )
+        inserted_dft += getattr(meta_dft, "n_inserted", 0)
+        existing_dft += getattr(meta_dft, "n_existing", 0)
+
+        meta_ref = qcf.submit_singlepoints_in_dataset(
+            ds_sp, spec_names=[reference_spec_name], tag=tag_reference_grad,
+        )
+        inserted_ref += getattr(meta_ref, "n_inserted", 0)
+        existing_ref += getattr(meta_ref, "n_existing", 0)
+    logger.info(
+        f"  DFT gradients: {inserted_dft} new, {existing_dft} existing (tag '{tag_dft_grad}')."
+    )
+    logger.info(
+        f"  Ref gradients: {inserted_ref} new, {existing_ref} existing (tag '{tag_reference_grad}')."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — wait for completion
+# ---------------------------------------------------------------------------
+
+def wait_for_nm_completion(
+    sp_dsets: dict, all_spec_names: List[str], wait_interval: int,
+    logger: logging.Logger,
+):
+    """Poll until every (system × entry × spec) record is terminal.
+
+    ``all_spec_names`` should include both the DFT functionals and the
+    reference spec name (all lowercase).
+    """
+    while True:
+        complete = incomplete = error = 0
+        for ds_sp in sp_dsets.values():
+            for entry_name in ds_sp.entry_names:
+                for spec_key in all_spec_names:
+                    record = ds_sp.get_record(entry_name, spec_key)
+                    if record is None:
+                        continue
+                    if is_complete(record.status):
+                        complete += 1
+                    elif is_incomplete(record.status):
+                        incomplete += 1
+                    elif is_error(record.status):
+                        error += 1
+        if incomplete == 0:
+            logger.info(
+                f"  NM SP: Complete: {complete}, Error: {error} {bcheck}"
+            )
+            return complete, error
+        logger.info(
+            f"  NM SP: {complete} done, {incomplete} running, {error} err"
+        )
+        logger.info(f"  Waiting {wait_interval}s before rechecking...")
+        time.sleep(wait_interval)
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — compute per-method force-RMSD vs reference
+# ---------------------------------------------------------------------------
+
+def compute_per_method_nm_metrics(
+    displaced: Dict[str, List[Tuple[str, Molecule, dict]]],
+    sp_dsets: dict, all_dft_functionals: List[str],
+    reference_spec_name: str, logger: logging.Logger,
+):
+    """For each DFT functional, compare its gradient to the reference at
+    every displaced geometry across every system. Returns
+    ``(metrics_dict, raw_deltas_dict)`` matching the trajectory layout.
+
+    Only the force component is meaningful here (energies at displaced
+    geometries aren't a benchmark target on their own). We reuse
+    ``per_step_deltas`` + ``summarize_method_metrics`` from
+    ``trajectory_metrics``; the energy entries get zeros so the
+    summariser's force outputs are the ones consumed downstream.
+    """
+    metrics: Dict[str, dict] = {}
+    raw_deltas: Dict[str, dict] = {}
+
+    for functional in all_dft_functionals:
+        per_system = []
+        skipped_systems = 0
+
+        for struct_name, entries in displaced.items():
+            ds_sp = sp_dsets.get(struct_name)
+            if ds_sp is None:
+                continue
+
+            ref_e, ref_g, dft_e, dft_g = [], [], [], []
+            n_atoms = None
+            for entry_name, _mol, _meta in entries:
+                de_dft, dg_dft = qcf.fetch_sp_energy_gradient(
+                    ds_sp, entry_name, functional,
+                )
+                de_ref, dg_ref = qcf.fetch_sp_energy_gradient(
+                    ds_sp, entry_name, reference_spec_name,
+                )
+                if dg_dft is None or dg_ref is None:
+                    continue
+                if n_atoms is None:
+                    n_atoms = dg_dft.shape[0]
+                # Energies aren't part of the NM benchmark — zero them.
+                ref_e.append(0.0)
+                ref_g.append(dg_ref)
+                dft_e.append(0.0)
+                dft_g.append(dg_dft)
+
+            if not ref_e:
+                skipped_systems += 1
+                continue
+
+            per_system.append(per_step_deltas(
+                np.asarray(ref_e), np.asarray(ref_g),
+                np.asarray(dft_e), np.asarray(dft_g),
+                n_atoms=n_atoms,
+            ))
+
+        if not per_system:
+            logger.warning(
+                f"  {functional}: no complete NM data — excluded."
+            )
+            continue
+
+        metrics[functional] = summarize_method_metrics(per_system)
+        raw_deltas[functional] = {
+            "delta_e_per_atom_meV": np.concatenate(
+                [d["delta_e_per_atom_meV"] for d in per_system]
+            ),
+            "delta_force_meV_per_A": np.concatenate(
+                [d["delta_force_meV_per_A"].ravel() for d in per_system]
+            ),
+        }
+        if skipped_systems:
+            logger.info(
+                f"  {functional}: {skipped_systems} systems had no complete records."
+            )
+    return metrics, raw_deltas
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def run_nm_sampling(
+    *, config, client, odset_dict: dict,
+    all_dft_functionals: List[str], dft_geom_functionals: dict,
+    n_adsorbate_atoms: int, res_folder: Path,
+    logger: logging.Logger,
+):
+    """Top-level driver for the normal-mode sampling benchmark.
+
+    Returns ``(metrics, raw_deltas)``: ``metrics`` is the per-method
+    summary dict (``rmsd_force`` etc.), ``raw_deltas`` is the
+    per-method concatenated delta arrays used by downstream plotting.
+    """
+    # Lowercase the functional spec list — same convention as the
+    # geom_benchmark trajectory analysis (be_hess / energy_benchmark also
+    # do this). qcf-astrochem stores specs lowercase and lookups are
+    # case-sensitive.
+    all_dft_functionals = [s.lower() for s in all_dft_functionals]
+    reference_spec_name = config.reference_grad_lot  # already lowercased by validator
+    all_spec_names = all_dft_functionals + [reference_spec_name]
+
+    padded_log(logger, "NM-sampling analysis (DFT vs CCSD(T) gradients)")
+
+    # 1. Collect optimised geometries
+    logger.info("\nCollecting equilibrium geometries…")
+    ref_mols = collect_optimized_geometries(
+        odset_dict, config.geometry_opt_lot, logger,
+    )
+    if not ref_mols:
+        logger.warning("\n  No usable equilibrium geometries — aborting.\n")
+        return None, {}
+
+    # 2. Submit Hessians + wait
+    padded_log(logger, "Hessian computations")
+    logger.info(
+        f"\nSubmitting Hessians at {config.hessian_lot} to tag "
+        f"'{config.tag_hessian}'…"
+    )
+    hess_ids = submit_system_hessians(
+        client, ref_mols,
+        config.hessian_lot, config.hessian_program,
+        config.hessian_keywords, config.tag_hessian, logger,
+    )
+    if hess_ids:
+        logger.info("\nWaiting for Hessian completion…")
+        qcf.check_jobs_status(client, hess_ids, logger)
+
+    # 3. Fetch normal modes + classify
+    padded_log(logger, "Normal-mode classification")
+    mode_data = collect_system_normal_modes(
+        client, ref_mols, config.hessian_lot,
+        n_adsorbate_atoms=n_adsorbate_atoms,
+        inter_threshold=config.inter_threshold,
+        bend_max_cm=config.bend_max_cm,
+        logger=logger,
+    )
+    if not mode_data:
+        logger.warning("\n  No usable normal-mode data — aborting.\n")
+        return None, {}
+
+    # 4. Select picks + generate displaced molecules
+    padded_log(logger, "Displacement generation")
+    displaced = build_displaced_molecules(
+        mode_data, dict(config.bands),
+        freq_max_imag_cm=config.freq_max_imag_cm,
+        extra_amplitudes_lowest_count=config.extra_amplitudes_lowest_count,
+        extra_amplitude_factor=config.extra_amplitude_factor,
+        logger=logger,
+    )
+    if not displaced:
+        logger.warning("\n  No displacements generated — aborting.\n")
+        return None, {}
+
+    # 5. Build SP datasets
+    logger.info("\nBuilding nm_sampling singlepoint datasets…")
+    sp_dsets = build_nm_sp_datasets(
+        client, displaced,
+        all_dft_functionals=all_dft_functionals,
+        reference_spec_name=reference_spec_name,
+        reference_grad_lot=config.reference_grad_lot,
+        reference_grad_program=config.reference_grad_program,
+        reference_grad_keywords=config.reference_grad_keywords,
+        dft_program=config.dft_program,
+        dft_keyword=config.dft_keyword,
+        logger=logger,
+    )
+
+    # 6. Submit
+    padded_log(logger, "Submitting NM gradient SPs")
+    submit_nm_singlepoints(
+        sp_dsets, all_dft_functionals, reference_spec_name,
+        config.tag_dft_grad, config.tag_reference_grad, logger,
+    )
+
+    # 7. Wait
+    logger.info("\nWaiting for NM gradient SPs to complete…")
+    wait_for_nm_completion(
+        sp_dsets, all_spec_names, wait_interval=200, logger=logger,
+    )
+
+    # 8. Compute metrics
+    logger.info("\nComputing per-method NM force metrics…")
+    metrics, raw_deltas = compute_per_method_nm_metrics(
+        displaced, sp_dsets, all_dft_functionals,
+        reference_spec_name, logger,
+    )
+
+    padded_log(logger, "NM-SAMPLING BENCHMARK RESULTS", padding_char=gear)
+    padded_log(logger, "NM-SAMPLING FORCE RMSE (meV/Å)")
+    # Single-metric benchmark — no z-score combination needed; pass
+    # ranking_df=None so the per-group winners are picked by raw RMSD_F
+    # (identical order to z-scored RMSD_F, but with a more honest label).
+    log_trajectory_metrics_per_group(
+        logger, metrics, dft_geom_functionals, ranking_df=None,
+    )
+    logger.info("")
+    logger.info("  Note — RMSD_F is the root-mean-square error of the per-")
+    logger.info("         Cartesian-component DFT force vs the CCSD(T) reference")
+    logger.info("         force, aggregated across every displaced geometry and")
+    logger.info("         every binding site:")
+    logger.info("")
+    logger.info("           RMSD_F = sqrt( mean( (F_DFT_xyz - F_CCSDT_xyz)^2 ) )")
+    logger.info("")
+    logger.info("         Per-method raw values and displacement metadata are")
+    logger.info("         available in:")
+    logger.info("")
+    logger.info("           json_data/results_nm_sampling.json   (per-method metrics)")
+    logger.info("")
+
+    # Persist JSON
+    folder_path_json = res_folder / "json_data"
+    folder_path_json.mkdir(parents=True, exist_ok=True)
+    metrics_json = {m: {k: v for k, v in d.items()} for m, d in metrics.items()}
+    (folder_path_json / "results_nm_sampling.json").write_text(
+        json.dumps(metrics_json, indent=4, default=str)
+    )
+    logger.info(
+        f"\n  NM-sampling metrics written to {folder_path_json}/\n"
+    )
+
+    return metrics, raw_deltas

--- a/beep/core/nm_sampling_workflow.py
+++ b/beep/core/nm_sampling_workflow.py
@@ -37,6 +37,7 @@ from ..adapters.qcfractal_adapter import is_complete, is_incomplete, is_error
 from .logging_utils import padded_log, log_trajectory_metrics_per_group
 from .normal_mode_sampling import (
     classify_mode, select_modes, displace_along_mode,
+    write_molden, write_modes_json,
 )
 from .trajectory_metrics import per_step_deltas, summarize_method_metrics
 
@@ -153,11 +154,13 @@ def collect_system_normal_modes(
             continue
 
         masses = np.asarray(mol_from_record.masses)
+        positions = np.asarray(mol_from_record.geometry).reshape(-1, 3)
         classes = []
         for i, freq in enumerate(freqs_cm):
             cls = classify_mode(
                 mode_cart=modes_cart[i],
                 masses=masses,
+                positions=positions,
                 n_adsorbate_atoms=n_adsorbate_atoms,
                 frequency_cm=float(np.real(freq)),
                 inter_threshold=inter_threshold,
@@ -536,6 +539,93 @@ def run_nm_sampling(
     if not mode_data:
         logger.warning("\n  No usable normal-mode data — aborting.\n")
         return None, {}
+
+    # 3a. Persist visualisation artifacts (always — written BEFORE the
+    # imaginary-mode check so the user can open the .molden file to see
+    # which modes are imaginary and decide whether to re-optimise).
+    molden_dir = res_folder / "molden"
+    modes_json_dir = res_folder / "json_data"
+    molden_dir.mkdir(parents=True, exist_ok=True)
+    modes_json_dir.mkdir(parents=True, exist_ok=True)
+    for sysname, data in mode_data.items():
+        mol = data["mol"]
+        positions_bohr = np.asarray(mol.geometry).reshape(-1, 3)
+        write_molden(
+            molden_dir / f"{sysname}.molden",
+            symbols=list(mol.symbols),
+            geometry_bohr=positions_bohr,
+            frequencies_cm=data["frequencies_cm"],
+            modes_cart=data["modes_cart"],
+            title=f"BEEP nm_sampling — {sysname} ({config.hessian_lot})",
+        )
+        write_modes_json(
+            modes_json_dir / f"normal_modes_{sysname}.json",
+            symbols=list(mol.symbols),
+            geometry_bohr=positions_bohr,
+            frequencies_cm=data["frequencies_cm"],
+            modes_cart=data["modes_cart"],
+            classes=data["classes"],
+            n_adsorbate_atoms=n_adsorbate_atoms,
+            level_of_theory=config.hessian_lot,
+        )
+    logger.info(
+        f"\n  Normal-mode visualisations written to:\n"
+        f"    {molden_dir}/   (one .molden per system)\n"
+        f"    {modes_json_dir}/  (normal_modes_<system>.json)\n"
+    )
+
+    # 3b. Imaginary-mode sanity check. A genuine imaginary mode (|imag| above
+    # the noise threshold) means the geometry is a saddle, not a minimum —
+    # displacements around it would be meaningless. Abort unless the user
+    # explicitly opted in.
+    imag_offenders = {}
+    for sysname, data in mode_data.items():
+        freqs = data["frequencies_cm"]
+        n_imag = int(np.sum(np.abs(np.imag(freqs)) > config.freq_max_imag_cm))
+        if n_imag > 0:
+            imag_offenders[sysname] = n_imag
+    if imag_offenders:
+        msg_lines = [
+            f"  {s}: {n} imaginary mode(s) with |imag| > "
+            f"{config.freq_max_imag_cm} cm⁻¹"
+            for s, n in imag_offenders.items()
+        ]
+        if config.allow_imaginary_modes:
+            logger.warning(
+                "\n  WARNING: imaginary frequencies detected — proceeding "
+                "because allow_imaginary_modes=true:\n  " + "\n  ".join(msg_lines)
+                + "\n"
+            )
+        else:
+            logger.error(
+                "\n  ABORT: imaginary frequencies detected at the equilibrium "
+                "geometry — the system is a saddle, not a minimum:\n  "
+                + "\n  ".join(msg_lines)
+                + f"\n  Open {molden_dir}/<system>.molden to see which "
+                "modes are imaginary."
+                + "\n  Re-optimise the geometry before nm_sampling, or set "
+                "allow_imaginary_modes=true to override.\n"
+            )
+            raise RuntimeError(
+                f"nm_sampling aborted: imaginary modes in "
+                f"{list(imag_offenders)}"
+            )
+
+    # 3c. Pre-run exit. The user just wants to inspect the modes before
+    # committing the CCSD(T) gradient budget; nothing past this point gets
+    # submitted. Re-running with pre_run=false picks up where this left off
+    # (Hessians dedup, no recompute).
+    if config.pre_run:
+        padded_log(
+            logger,
+            "Pre-run complete: modes computed, no gradient SPs submitted",
+            padding_char=gear,
+        )
+        logger.info(
+            f"\n  Inspect the modes in {molden_dir}/ before re-running with "
+            "pre_run=false.\n"
+        )
+        return mode_data, {}
 
     # 4. Select picks + generate displaced molecules
     padded_log(logger, "Displacement generation")

--- a/beep/core/normal_mode_sampling.py
+++ b/beep/core/normal_mode_sampling.py
@@ -1,0 +1,287 @@
+"""Normal-mode displacement sampling — pure math.
+
+Used by the ``nm_sampling`` workflow to:
+  1. Run vibrational analysis on a Hessian record (wraps ``core.zpve``).
+  2. Classify each mode as intermolecular / bending / stretching via
+     fragment-COM projection.
+  3. Pick the lowest-frequency modes from each band, up to a configured cap.
+  4. Generate ± displaced Cartesian geometries at a target RMS amplitude.
+
+No QCFractal dependencies — all functions take plain numpy arrays plus a
+qcelemental Molecule. The workflow layer is responsible for fetching the
+Hessian record off the server and unpacking it into the array shape used here.
+"""
+from typing import Dict, List, Literal, Tuple
+
+import numpy as np
+
+from .zpve import _vibanal_wfn
+
+
+# Bohr ↔ Å (CODATA 2018). qcelemental has these too but inlining keeps the
+# module dependency-light + matches the constants used in trajectory_metrics.
+_BOHR_TO_A = 0.529177210903
+
+
+ModeBand = Literal["intermolecular", "bending", "stretching"]
+
+
+# ---------------------------------------------------------------------------
+# Hessian → normal modes (wrap zpve._vibanal_wfn)
+# ---------------------------------------------------------------------------
+
+def extract_normal_modes_from_hessian_record(
+    hess: np.ndarray, molecule, energy: float = 0.0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Run vibrational analysis on a Hessian.
+
+    Parameters
+    ----------
+    hess : (3N, 3N) ndarray
+        Non-mass-weighted Cartesian Hessian, units ``Eh / bohr²``. Shape
+        matches the raw ``record.return_result`` of a hessian SP after
+        reshape.
+    molecule : qcelemental.models.Molecule
+        Geometry + atomic masses container.
+    energy : float, optional
+        Electronic energy (Eh). Only used by ``_vibanal_wfn`` to populate
+        the thermodynamic info dict; the modes themselves do not depend
+        on it.
+
+    Returns
+    -------
+    frequencies_cm : (n_vib,) complex ndarray
+        Vibrational frequencies in cm⁻¹. Imaginary frequencies appear as
+        purely imaginary complex values (real part 0); real frequencies
+        appear with imaginary part 0. Translation/rotation modes are
+        stripped from the array.
+    modes_cart : (n_vib, n_atoms, 3) ndarray
+        Cartesian (un-mass-weighted) displacement pattern per mode.
+        Direction only — the absolute scale follows numpy's eigh
+        normalisation and gets renormalised by ``displace_along_mode``.
+    """
+    vibinfo, _therminfo = _vibanal_wfn(hess=hess, molecule=molecule, energy=energy)
+    trv = vibinfo["TRV"].data           # list of "TR" or "V" per mode
+    omega = vibinfo["omega"].data       # (ndof,) complex
+    modes = vibinfo["modes_cart"].data  # (ndof, n_atoms, 3)
+
+    keep = [i for i, label in enumerate(trv) if label == "V"]
+    if not keep:
+        # All TR — shouldn't happen for a bound molecule but be safe.
+        return np.empty(0, dtype=complex), np.empty((0, *modes.shape[1:]))
+    return omega[keep], modes[keep]
+
+
+# ---------------------------------------------------------------------------
+# Mode classification
+# ---------------------------------------------------------------------------
+
+def classify_mode(
+    mode_cart: np.ndarray,
+    masses: np.ndarray,
+    n_adsorbate_atoms: int,
+    frequency_cm: float,
+    inter_threshold: float = 0.5,
+    bend_max_cm: float = 1500.0,
+) -> ModeBand:
+    """Classify a single normal mode.
+
+    Uses a two-step rule:
+
+      1. Compute ``f_inter`` — the fraction of the mode's kinetic energy
+         that goes into rigid fragment-COM translation (adsorbate vs
+         cluster). If ``f_inter > inter_threshold`` the mode is labelled
+         *intermolecular* — it primarily moves the adsorbate against the
+         cluster.
+
+      2. Otherwise the mode is intramolecular; split by frequency:
+         ``frequency_cm < bend_max_cm`` → *bending*, else *stretching*.
+         (Frequency is a robust separator for intramolecular modes;
+         only for mixed-character modes does it fail, which is exactly
+         what step 1 catches.)
+
+    Fragment convention: the **last** ``n_adsorbate_atoms`` rows are the
+    adsorbate, the rest are the cluster — same convention BEEP uses
+    everywhere else (see ``reference_beep_last_molecule_adsorbate``).
+
+    Parameters
+    ----------
+    mode_cart : (n_atoms, 3) ndarray
+        Cartesian displacement pattern of the mode (units irrelevant —
+        only the relative atomic motion is used).
+    masses : (n_atoms,) ndarray
+        Atomic masses (amu).
+    n_adsorbate_atoms : int
+        Number of trailing atoms that constitute the adsorbate.
+    frequency_cm : float
+        Mode frequency (real part if complex) in cm⁻¹.
+    inter_threshold : float, default 0.5
+        ``f_inter`` above this → intermolecular.
+    bend_max_cm : float, default 1500.0
+        Intramolecular cutoff between bending and stretching.
+    """
+    n_atoms = mode_cart.shape[0]
+    if n_adsorbate_atoms <= 0 or n_adsorbate_atoms >= n_atoms:
+        # Degenerate fragmenting (whole system or empty) — call everything
+        # intramolecular and let the frequency cut decide.
+        f_inter = 0.0
+    else:
+        cluster_idx = slice(0, n_atoms - n_adsorbate_atoms)
+        ads_idx = slice(n_atoms - n_adsorbate_atoms, n_atoms)
+
+        m_cluster = masses[cluster_idx]
+        m_ads = masses[ads_idx]
+        v_cluster = mode_cart[cluster_idx]
+        v_ads = mode_cart[ads_idx]
+
+        com_cluster = (m_cluster[:, None] * v_cluster).sum(axis=0) / m_cluster.sum()
+        com_ads = (m_ads[:, None] * v_ads).sum(axis=0) / m_ads.sum()
+
+        # Kinetic energy carried by fragment-COM motion (relative to the
+        # whole-system COM, which is zero for a TR-projected mode).
+        k_inter = (
+            m_cluster.sum() * float(np.dot(com_cluster, com_cluster))
+            + m_ads.sum() * float(np.dot(com_ads, com_ads))
+        )
+        k_total = float(np.einsum("a,ai,ai->", masses, mode_cart, mode_cart))
+        f_inter = k_inter / k_total if k_total > 0.0 else 0.0
+
+    if f_inter > inter_threshold:
+        return "intermolecular"
+    if frequency_cm < bend_max_cm:
+        return "bending"
+    return "stretching"
+
+
+# ---------------------------------------------------------------------------
+# Per-band selection
+# ---------------------------------------------------------------------------
+
+def select_modes(
+    frequencies_cm: np.ndarray,
+    classes: List[str],
+    band_caps: Dict[str, int],
+    band_amplitudes: Dict[str, float],
+    freq_max_imag_cm: float = 50.0,
+    extra_amplitudes_lowest_count: int = 1,
+    extra_amplitude_factor: float = 2.0,
+) -> List[Tuple[int, float, str]]:
+    """Pick which modes to displace and at what amplitude.
+
+    Per band, take the ``cap`` lowest-frequency modes whose imaginary
+    component is below the threshold. The N lowest-frequency entries of
+    the final picked set (across all bands) get a second amplitude
+    appended at ``amplitude × extra_amplitude_factor``.
+
+    Parameters
+    ----------
+    frequencies_cm : (n_modes,) complex ndarray
+        Mode frequencies. Real frequencies have ``imag == 0``; imaginary
+        frequencies have ``real == 0``.
+    classes : list of str, length n_modes
+        Each element is "intermolecular", "bending", or "stretching".
+    band_caps, band_amplitudes : dict
+        Per-band cap (int) and amplitude (Å, RMS Cartesian).
+    freq_max_imag_cm : float, default 50.0
+        Drop modes whose |imag| exceeds this magnitude.
+    extra_amplitudes_lowest_count : int, default 1
+        Number of lowest-frequency selected modes that get the extra
+        amplitude.
+    extra_amplitude_factor : float, default 2.0
+        Multiplier for the extra-amplitude entries.
+
+    Returns
+    -------
+    list of (mode_index, amplitude_A, band_label)
+        Each entry represents a displacement pair (the caller submits
+        both + and − signs separately). Sorted ascending by frequency
+        within bands; extra-amplitude entries trail their primary entry.
+    """
+    selected: List[Tuple[int, float, str]] = []
+
+    # Build per-band candidate lists (mode_index, real_freq), filtered.
+    candidates: Dict[str, List[Tuple[int, float]]] = {b: [] for b in band_caps}
+    for idx, (omega, band) in enumerate(zip(frequencies_cm, classes)):
+        if band not in candidates:
+            continue
+        re = float(np.real(omega))
+        im = float(np.imag(omega))
+        if abs(im) > freq_max_imag_cm:
+            continue
+        candidates[band].append((idx, re))
+
+    # Sort each band's candidates by ascending real frequency, take the cap.
+    for band, cap in band_caps.items():
+        picks = sorted(candidates[band], key=lambda x: x[1])[: int(cap)]
+        amp = float(band_amplitudes[band])
+        for idx, _freq in picks:
+            selected.append((idx, amp, band))
+
+    # Identify the N lowest-frequency entries across the whole selection
+    # and append extra-amplitude duplicates.
+    if extra_amplitudes_lowest_count > 0 and selected:
+        # Pair each entry with its frequency for ranking.
+        ranked = sorted(
+            range(len(selected)),
+            key=lambda i: float(np.real(frequencies_cm[selected[i][0]])),
+        )
+        extras = []
+        for slot in ranked[: int(extra_amplitudes_lowest_count)]:
+            idx, amp, band = selected[slot]
+            extras.append((idx, amp * float(extra_amplitude_factor), band))
+        selected.extend(extras)
+
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Displacement geometry generation
+# ---------------------------------------------------------------------------
+
+def displace_along_mode(
+    geometry_bohr: np.ndarray,
+    mode_cart: np.ndarray,
+    amplitude_A: float,
+    sign: int = +1,
+) -> np.ndarray:
+    """Apply a ±-signed displacement along a mode to a geometry.
+
+    The mode is scaled so its RMS Cartesian length (over all atoms) equals
+    ``amplitude_A`` (in Å), converted to bohr, then added to the
+    equilibrium geometry with the given sign.
+
+    Parameters
+    ----------
+    geometry_bohr : (n_atoms, 3) ndarray
+        Equilibrium Cartesian geometry in bohr.
+    mode_cart : (n_atoms, 3) ndarray
+        Mode direction in Cartesians (un-mass-weighted). Magnitude is
+        irrelevant — only the direction is used.
+    amplitude_A : float
+        Target RMS Cartesian displacement of all atoms, in Å.
+    sign : int, default +1
+        ``+1`` or ``-1``.
+
+    Returns
+    -------
+    (n_atoms, 3) ndarray — displaced geometry in bohr.
+    """
+    if sign not in (+1, -1):
+        raise ValueError(f"sign must be +1 or -1, got {sign}")
+    n_atoms = mode_cart.shape[0]
+    if n_atoms == 0:
+        return geometry_bohr.copy()
+
+    # RMS Cartesian length of the mode vector, in whatever units the input
+    # came with. We rescale to amplitude_A (in bohr) — RMS of a target
+    # displacement field of RMS=A_bohr has Σ|v|² = 3 N A_bohr² (each of
+    # 3 N components contributes A_bohr²/(3N) on average, and the RMS of
+    # a vector with 3 N components is √(Σ|v_i|² / (3N))).
+    sum_sq = float(np.einsum("ai,ai->", mode_cart, mode_cart))
+    if sum_sq <= 0.0:
+        return geometry_bohr.copy()
+    rms_mode = np.sqrt(sum_sq / (3.0 * n_atoms))
+    amp_bohr = amplitude_A / _BOHR_TO_A
+    scale = amp_bohr / rms_mode
+
+    return geometry_bohr + sign * scale * mode_cart

--- a/beep/core/normal_mode_sampling.py
+++ b/beep/core/normal_mode_sampling.py
@@ -3,14 +3,18 @@
 Used by the ``nm_sampling`` workflow to:
   1. Run vibrational analysis on a Hessian record (wraps ``core.zpve``).
   2. Classify each mode as intermolecular / bending / stretching via
-     fragment-COM projection.
+     rigid-body kinetic-energy projection (fragment-COM translation +
+     rotation about COM).
   3. Pick the lowest-frequency modes from each band, up to a configured cap.
   4. Generate ± displaced Cartesian geometries at a target RMS amplitude.
+  5. Write a Molden-format file + a programmatic JSON for visualization.
 
 No QCFractal dependencies — all functions take plain numpy arrays plus a
 qcelemental Molecule. The workflow layer is responsible for fetching the
 Hessian record off the server and unpacking it into the array shape used here.
 """
+import json
+from pathlib import Path
 from typing import Dict, List, Literal, Tuple
 
 import numpy as np
@@ -76,9 +80,46 @@ def extract_normal_modes_from_hessian_record(
 # Mode classification
 # ---------------------------------------------------------------------------
 
+def _fragment_rigid_kinetic(
+    positions: np.ndarray, masses: np.ndarray, mode_cart: np.ndarray,
+) -> float:
+    """Rigid-body kinetic energy (× 2) of one fragment in a normal mode.
+
+    Returns ``K_trans + K_rot`` for the fragment, where
+
+      * ``K_trans = M_f · |c_f|²``       (fragment-COM translation)
+      * ``K_rot   = Lᵀ · I⁺ · L``        (rotation about fragment COM)
+
+    ``c_f`` is the mass-weighted COM displacement, ``L`` the angular
+    momentum about the COM, and ``I⁺`` the Moore–Penrose pseudo-inverse
+    of the inertia tensor (which gracefully handles single-atom and
+    collinear fragments — for those the null-space component of ``L``
+    is projected out and contributes zero rotational KE).
+
+    The constant ``½`` is dropped — only the ratio ``K_rigid / K_total``
+    is used downstream, so the factor cancels.
+    """
+    if masses.size == 0:
+        return 0.0
+    M = float(masses.sum())
+    if M <= 0.0:
+        return 0.0
+    com_pos = (masses[:, None] * positions).sum(axis=0) / M
+    com_disp = (masses[:, None] * mode_cart).sum(axis=0) / M
+    rho = positions - com_pos
+    L = (masses[:, None] * np.cross(rho, mode_cart)).sum(axis=0)
+    rho_sq = float((masses * (rho * rho).sum(axis=1)).sum())
+    I = rho_sq * np.eye(3) - np.einsum("a,ai,aj->ij", masses, rho, rho)
+    omega = np.linalg.pinv(I) @ L
+    k_trans = M * float(com_disp @ com_disp)
+    k_rot = float(L @ omega)
+    return k_trans + k_rot
+
+
 def classify_mode(
     mode_cart: np.ndarray,
     masses: np.ndarray,
+    positions: np.ndarray,
     n_adsorbate_atoms: int,
     frequency_cm: float,
     inter_threshold: float = 0.5,
@@ -89,16 +130,24 @@ def classify_mode(
     Uses a two-step rule:
 
       1. Compute ``f_inter`` — the fraction of the mode's kinetic energy
-         that goes into rigid fragment-COM translation (adsorbate vs
-         cluster). If ``f_inter > inter_threshold`` the mode is labelled
+         carried by **rigid-body motion of each fragment** (translation
+         of the fragment COM plus rotation about that COM). If
+         ``f_inter > inter_threshold`` the mode is labelled
          *intermolecular* — it primarily moves the adsorbate against the
-         cluster.
+         cluster, whether by translation or by libration.
 
       2. Otherwise the mode is intramolecular; split by frequency:
          ``frequency_cm < bend_max_cm`` → *bending*, else *stretching*.
          (Frequency is a robust separator for intramolecular modes;
          only for mixed-character modes does it fail, which is exactly
          what step 1 catches.)
+
+    Including the rotational term is essential for low-frequency
+    librations: a libration is a pure intramolecular rotation of one
+    fragment about its own COM, so the COM *displacement* is ~0 even
+    though every atom in the fragment is moving relative to the rest of
+    the complex. A COM-displacement-only ratio misses librations and
+    labels them as internal bends.
 
     Fragment convention: the **last** ``n_adsorbate_atoms`` rows are the
     adsorbate, the rest are the cluster — same convention BEEP uses
@@ -111,6 +160,10 @@ def classify_mode(
         only the relative atomic motion is used).
     masses : (n_atoms,) ndarray
         Atomic masses (amu).
+    positions : (n_atoms, 3) ndarray
+        Equilibrium atomic positions, same Cartesian frame as
+        ``mode_cart``. Used to compute angular momenta + inertia
+        tensors about each fragment COM. Units cancel in the ratio.
     n_adsorbate_atoms : int
         Number of trailing atoms that constitute the adsorbate.
     frequency_cm : float
@@ -126,25 +179,17 @@ def classify_mode(
         # intramolecular and let the frequency cut decide.
         f_inter = 0.0
     else:
-        cluster_idx = slice(0, n_atoms - n_adsorbate_atoms)
-        ads_idx = slice(n_atoms - n_adsorbate_atoms, n_atoms)
-
-        m_cluster = masses[cluster_idx]
-        m_ads = masses[ads_idx]
-        v_cluster = mode_cart[cluster_idx]
-        v_ads = mode_cart[ads_idx]
-
-        com_cluster = (m_cluster[:, None] * v_cluster).sum(axis=0) / m_cluster.sum()
-        com_ads = (m_ads[:, None] * v_ads).sum(axis=0) / m_ads.sum()
-
-        # Kinetic energy carried by fragment-COM motion (relative to the
-        # whole-system COM, which is zero for a TR-projected mode).
-        k_inter = (
-            m_cluster.sum() * float(np.dot(com_cluster, com_cluster))
-            + m_ads.sum() * float(np.dot(com_ads, com_ads))
+        n_cluster = n_atoms - n_adsorbate_atoms
+        k_rigid = (
+            _fragment_rigid_kinetic(
+                positions[:n_cluster], masses[:n_cluster], mode_cart[:n_cluster],
+            )
+            + _fragment_rigid_kinetic(
+                positions[n_cluster:], masses[n_cluster:], mode_cart[n_cluster:],
+            )
         )
         k_total = float(np.einsum("a,ai,ai->", masses, mode_cart, mode_cart))
-        f_inter = k_inter / k_total if k_total > 0.0 else 0.0
+        f_inter = k_rigid / k_total if k_total > 0.0 else 0.0
 
     if f_inter > inter_threshold:
         return "intermolecular"
@@ -285,3 +330,127 @@ def displace_along_mode(
     scale = amp_bohr / rms_mode
 
     return geometry_bohr + sign * scale * mode_cart
+
+
+# ---------------------------------------------------------------------------
+# Molden + JSON writers (visualization / programmatic post-analysis)
+# ---------------------------------------------------------------------------
+
+def write_molden(
+    filepath,
+    symbols: List[str],
+    geometry_bohr: np.ndarray,
+    frequencies_cm: np.ndarray,
+    modes_cart: np.ndarray,
+    title: str = "BEEP nm_sampling normal modes",
+) -> None:
+    """Write Molden-format normal-mode file (visualisable in Avogadro, jmol, IboView).
+
+    Imaginary frequencies are written with a negative sign (Molden's
+    convention for saddle-direction modes).
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Output ``.molden`` path.
+    symbols : list of str, length n_atoms
+        Atomic symbols.
+    geometry_bohr : (n_atoms, 3) ndarray
+        Atomic positions in Bohr.
+    frequencies_cm : (n_vib,) complex ndarray
+        Vibrational frequencies; real modes have ``imag == 0``, imaginary
+        modes have ``real == 0`` (qcelemental convention).
+    modes_cart : (n_vib, n_atoms, 3) ndarray
+        Cartesian displacement patterns (un-mass-weighted).
+    title : str
+        Title line written into the ``[Title]`` block.
+    """
+    import qcelemental as qcel
+    atomic_numbers = [qcel.periodictable.to_atomic_number(s) for s in symbols]
+    n_atoms = len(symbols)
+
+    lines = ["[Molden Format]", "[Title]", title, "[Atoms] AU"]
+    for i, (sym, Z) in enumerate(zip(symbols, atomic_numbers), start=1):
+        x, y, z = geometry_bohr[i - 1]
+        lines.append(
+            f"{sym:<3s} {i:>5d} {Z:>4d}  "
+            f"{x:>16.10f} {y:>16.10f} {z:>16.10f}"
+        )
+
+    lines.append("[FREQ]")
+    for omega in frequencies_cm:
+        re = float(np.real(omega))
+        im = float(np.imag(omega))
+        value = -abs(im) if abs(im) > abs(re) else re
+        lines.append(f"{value:>14.4f}")
+
+    lines.append("[FR-COORD]")
+    for sym, (x, y, z) in zip(symbols, geometry_bohr):
+        lines.append(f"{sym:<3s} {x:>16.10f} {y:>16.10f} {z:>16.10f}")
+
+    lines.append("[FR-NORM-COORD]")
+    for i, mode in enumerate(modes_cart, start=1):
+        lines.append(f"vibration {i}")
+        for dx, dy, dz in mode:
+            lines.append(f"  {dx:>14.10f} {dy:>14.10f} {dz:>14.10f}")
+
+    Path(filepath).write_text("\n".join(lines) + "\n")
+
+
+def write_modes_json(
+    filepath,
+    symbols: List[str],
+    geometry_bohr: np.ndarray,
+    frequencies_cm: np.ndarray,
+    modes_cart: np.ndarray,
+    classes: List[str],
+    n_adsorbate_atoms: int,
+    level_of_theory: str = "",
+) -> None:
+    """Write a per-system normal-mode JSON.
+
+    Matches the structure of the test-case file BEEP was validated against
+    (``h2s_h2o_modes.json``): symbols, geometry in Å, the fragment
+    boundary (BEEP convention: last ``n_adsorbate_atoms`` rows are the
+    adsorbate), and a list of ``{freq_cm, disp, class}`` entries per mode.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Output ``.json`` path.
+    symbols : list of str, length n_atoms
+    geometry_bohr : (n_atoms, 3) ndarray
+        Positions in Bohr — converted to Å on write.
+    frequencies_cm : (n_vib,) complex ndarray
+    modes_cart : (n_vib, n_atoms, 3) ndarray
+    classes : list of str, length n_vib
+        Output of ``classify_mode`` per mode.
+    n_adsorbate_atoms : int
+        BEEP convention: last N atoms are the adsorbate.
+    level_of_theory : str
+        For the ``level_of_theory`` key — e.g. ``hf_def2-svp``.
+    """
+    n_atoms = len(symbols)
+    geom_A = (np.asarray(geometry_bohr) * _BOHR_TO_A).tolist()
+    adsorbate_index = list(range(n_atoms - n_adsorbate_atoms, n_atoms))
+
+    modes = []
+    for omega, disp, cls in zip(frequencies_cm, modes_cart, classes):
+        re = float(np.real(omega))
+        im = float(np.imag(omega))
+        freq = re if abs(re) > abs(im) else im  # store imag with positive magnitude
+        modes.append({
+            "freq_cm": freq,
+            "is_imaginary": bool(abs(im) > abs(re)),
+            "class": cls,
+            "disp": np.asarray(disp).tolist(),
+        })
+
+    payload = {
+        "level_of_theory": level_of_theory,
+        "symbols": list(symbols),
+        "geometry_A": geom_A,
+        "adsorbate_atom_index": adsorbate_index,
+        "modes": modes,
+    }
+    Path(filepath).write_text(json.dumps(payload, indent=2))

--- a/beep/core/plotting_utils.py
+++ b/beep/core/plotting_utils.py
@@ -326,3 +326,82 @@ def zpve_plot(x: np.ndarray, y: np.ndarray, fit_params: List[float]) -> plt.Figu
 
     return fig
 
+
+def trajectory_error_histograms(
+    raw_deltas, mol_name, plot_path, ranking_df=None,
+):
+    """Per-component force-error distributions per DFT functional.
+
+    One single-panel histogram per functional (force errors in meV/Å vs
+    the reference at the same geometry), plus a summary violin plot
+    across all functionals. Energy is not shown — absolute energies
+    aren't part of the geom_benchmark trajectory score (see the
+    workflow methodology block in the log).
+
+    Parameters
+    ----------
+    raw_deltas : dict
+        ``{functional → {"delta_force_meV_per_A": ndarray, ...}}`` with
+        flat arrays concatenated across all systems & steps.
+        ``delta_e_per_atom_meV``, if present, is ignored.
+    mol_name : str
+        Target adsorbate name (for filenames).
+    plot_path : str
+        Output directory; created by caller.
+    ranking_df : pd.DataFrame, optional
+        If provided, functionals are sorted by ``combined_score`` in
+        the summary plot (best at top of violins).
+    """
+    if not raw_deltas:
+        return
+
+    methods = list(raw_deltas.keys())
+    if ranking_df is not None:
+        ranked_methods = [m for m in ranking_df.index if m in raw_deltas]
+        methods = ranked_methods + [m for m in methods if m not in ranked_methods]
+
+    # --- Per-functional force-error histograms ---
+    for m in methods:
+        df = raw_deltas[m]["delta_force_meV_per_A"]
+        rmsd_f = float(np.sqrt(np.mean(df ** 2)))
+
+        fig, ax_f = plt.subplots(figsize=(6, 4))
+        ax_f.hist(df, bins=80, color="#7d7d7d", edgecolor="#333333",
+                  linewidth=0.3)
+        ax_f.axvline(0.0, color="black", linewidth=0.8, linestyle="--")
+        ax_f.set_xlabel(r"$F_{\mathrm{DFT}} - F_{\mathrm{ref}}$  /  meV·$\AA^{-1}$")
+        ax_f.set_ylabel("count")
+        ax_f.text(0.97, 0.95, f"RMSD: {rmsd_f:.2f} meV/Å",
+                  transform=ax_f.transAxes, ha="right", va="top",
+                  fontsize=10)
+
+        fig.suptitle(f"{mol_name} — {m}")
+        plt.tight_layout()
+        safe_name = m.replace("/", "_").replace(" ", "_")
+        plt.savefig(f"{plot_path}/traj_errors_{safe_name}.svg")
+        plt.close(fig)
+
+    # --- Summary: violins across all functionals, force only ---
+    fig, ax_f = plt.subplots(figsize=(max(8, len(methods) * 0.6), 5))
+
+    f_data = [raw_deltas[m]["delta_force_meV_per_A"] for m in methods]
+    parts_f = ax_f.violinplot(f_data, showmeans=True, showmedians=False)
+    for pc in parts_f["bodies"]:
+        pc.set_facecolor("#7d7d7d")
+        pc.set_alpha(0.7)
+    ax_f.set_xticks(range(1, len(methods) + 1))
+    ax_f.set_xticklabels(methods, rotation=90, fontsize=8)
+    ax_f.axhline(0.0, color="black", linewidth=0.6, linestyle="--")
+    ax_f.set_ylabel(r"$F_{\mathrm{DFT}} - F_{\mathrm{ref}}$  /  meV·$\AA^{-1}$")
+    if ranking_df is not None:
+        ax_f.set_title(
+            "Trajectory force errors per Cartesian component "
+            "(sorted by combined score)"
+        )
+    else:
+        ax_f.set_title("Trajectory force errors per Cartesian component")
+
+    plt.tight_layout()
+    plt.savefig(f"{plot_path}/traj_error_violins_{mol_name}.svg")
+    plt.close(fig)
+

--- a/beep/core/trajectory_metrics.py
+++ b/beep/core/trajectory_metrics.py
@@ -1,0 +1,170 @@
+"""
+Trajectory benchmark metrics — pure computation, no QCFractal deps.
+
+Energies are reported in meV/atom; gradient components (forces) in meV/Å.
+This matches the units used in MLP-validation literature (Bovolenta
+et al. 2025, A&A, Fig C.1) and makes the metrics directly comparable
+across cluster sizes.
+
+Conversion factors are taken from CODATA 2018 / qcelemental.
+"""
+from typing import Dict, Iterable
+
+import numpy as np
+import pandas as pd
+
+
+HARTREE_TO_MEV = 27211.386245988
+BOHR_TO_ANGSTROM = 0.529177210903
+HARTREE_PER_BOHR_TO_MEV_PER_A = HARTREE_TO_MEV / BOHR_TO_ANGSTROM
+
+
+def per_step_deltas(
+    ref_energies,
+    ref_gradients,
+    dft_energies,
+    dft_gradients,
+    n_atoms: int,
+) -> Dict[str, np.ndarray]:
+    """Compute per-trajectory-step (DFT − reference) deltas in MLP units.
+
+    Parameters
+    ----------
+    ref_energies, dft_energies : array-like, shape (n_steps,)
+        Total energies in hartree at each trajectory step.
+    ref_gradients, dft_gradients : array-like, shape (n_steps, n_atoms, 3)
+        Cartesian gradients in hartree/bohr at each trajectory step.
+    n_atoms : int
+        Number of atoms in the supermolecule, for per-atom energy
+        normalization.
+
+    Returns
+    -------
+    dict with keys:
+      ``delta_e_per_atom_meV``  — shape (n_steps,), meV/atom
+      ``delta_force_meV_per_A`` — shape (n_steps, n_atoms, 3), meV/Å
+    """
+    ref_e = np.asarray(ref_energies, dtype=float)
+    dft_e = np.asarray(dft_energies, dtype=float)
+    ref_g = np.asarray(ref_gradients, dtype=float)
+    dft_g = np.asarray(dft_gradients, dtype=float)
+
+    if ref_e.shape != dft_e.shape:
+        raise ValueError(
+            f"ref_energies shape {ref_e.shape} != dft_energies shape {dft_e.shape}"
+        )
+    if ref_g.shape != dft_g.shape:
+        raise ValueError(
+            f"ref_gradients shape {ref_g.shape} != dft_gradients shape {dft_g.shape}"
+        )
+    if n_atoms <= 0:
+        raise ValueError(f"n_atoms must be > 0, got {n_atoms}")
+
+    delta_e_per_atom_meV = (dft_e - ref_e) * HARTREE_TO_MEV / n_atoms
+    delta_force_meV_per_A = (dft_g - ref_g) * HARTREE_PER_BOHR_TO_MEV_PER_A
+    return {
+        "delta_e_per_atom_meV": delta_e_per_atom_meV,
+        "delta_force_meV_per_A": delta_force_meV_per_A,
+    }
+
+
+def summarize_method_metrics(
+    per_system_deltas: Iterable[Dict[str, np.ndarray]]
+) -> Dict[str, float]:
+    """Aggregate per-system delta arrays for one functional and summarize.
+
+    The energy and force deltas are concatenated across systems
+    (a trajectory of length N_i contributes N_i energy points and
+    3 · N_i · n_atoms_i force-component points), then reduced to
+    root-mean-square deviation (RMSD).
+
+    RMSD vs the reference is the right metric here: same mathematical
+    form as the equilibrium-geometry ``compare_rmsd``; outlier-sensitive
+    (a single bad gradient point — the failure mode that matters for
+    geometry optimization — surfaces clearly).
+
+    Force RMSD is taken over every Cartesian component (matching the
+    Bovolenta 2025 Fig C.1 convention). Energy RMSD is computed for
+    completeness — the geom_benchmark workflow does not use it (absolute
+    energies aren't meaningful for geometry ranking; use the
+    energy_benchmark workflow for relative-energy comparison).
+    """
+    per_system_deltas = list(per_system_deltas)
+    if not per_system_deltas:
+        return {
+            "rmsd_energy": float("nan"),
+            "rmsd_force": float("nan"),
+            "n_energy_points": 0,
+            "n_force_components": 0,
+        }
+
+    all_de = np.concatenate(
+        [np.asarray(d["delta_e_per_atom_meV"]).ravel() for d in per_system_deltas]
+    )
+    all_df = np.concatenate(
+        [np.asarray(d["delta_force_meV_per_A"]).ravel() for d in per_system_deltas]
+    )
+
+    return {
+        "rmsd_energy": float(np.sqrt(np.mean(all_de ** 2))),
+        "rmsd_force": float(np.sqrt(np.mean(all_df ** 2))),
+        "n_energy_points": int(all_de.size),
+        "n_force_components": int(all_df.size),
+    }
+
+
+def combined_zscore_ranking(
+    metrics_df: pd.DataFrame, weights: Dict[str, float]
+) -> pd.DataFrame:
+    """Combine per-method metrics into a weighted z-score ranking.
+
+    The metrics combined are taken from ``weights.keys()`` — the same
+    function therefore serves the 2-metric geom-benchmark case
+    (``rmsd_eq`` + ``rmsd_force``) and any future N-metric variant
+    (e.g. energy_benchmark) without modification.
+
+    For each metric column, computes ``z = (x − mean) / std`` across the
+    methods present in ``metrics_df`` (population std, ``ddof=0``).
+    Lower combined score = better functional.
+
+    Parameters
+    ----------
+    metrics_df : DataFrame
+        Index = method name. Columns must include every key of
+        ``weights``.
+    weights : dict
+        ``{metric_name → float}``. Determines which columns are combined
+        and how heavily each is weighted.
+
+    Returns
+    -------
+    DataFrame indexed by method, with z-score columns (named
+    ``z_<metric>``) plus ``combined_score``, sorted ascending by
+    ``combined_score``.
+
+    Notes
+    -----
+    A metric column where all methods are equal (zero std) contributes
+    ``0`` to every z-score — that dimension carries no ranking signal.
+    """
+    if not weights:
+        raise ValueError("weights must be non-empty")
+    metric_cols = list(weights.keys())
+    for col in metric_cols:
+        if col not in metrics_df.columns:
+            raise ValueError(f"metrics_df missing required column: {col}")
+
+    out = pd.DataFrame(index=metrics_df.index)
+    for col in metric_cols:
+        x = metrics_df[col].astype(float)
+        mean = float(x.mean())
+        std = float(x.std(ddof=0))
+        if std == 0 or np.isnan(std):
+            out[f"z_{col}"] = 0.0
+        else:
+            out[f"z_{col}"] = (x - mean) / std
+
+    out["combined_score"] = sum(
+        float(weights[col]) * out[f"z_{col}"] for col in metric_cols
+    )
+    return out.sort_values("combined_score")

--- a/beep/core/trajectory_workflow.py
+++ b/beep/core/trajectory_workflow.py
@@ -1,0 +1,421 @@
+"""Trajectory-benchmark orchestration helpers.
+
+Workflow-level glue for the ``geom_benchmark`` trajectory analysis: for
+each DFT functional, evaluate SP + gradient at every geometry along the
+reference optimization trajectory and report MAE/RMSE of energy
+(meV/atom) and forces (meV/Å) against the reference, plus a combined
+z-score-weighted ranking.
+
+The pure-math layer lives in :mod:`beep.core.trajectory_metrics`
+(``per_step_deltas``, ``summarize_method_metrics``,
+``combined_zscore_ranking``); the QCFractal I/O lives in
+:mod:`beep.adapters.qcfractal_adapter`. This module orchestrates the
+two against a benchmark's reference + DFT optimizations.
+
+Inspired by Bovolenta et al. 2025 (arXiv 2508.14219), Appendix C.2 /
+Fig C.1.
+"""
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from ..adapters import qcfractal_adapter as qcf
+from ..adapters.qcfractal_adapter import is_complete, is_incomplete, is_error
+from .logging_utils import (
+    padded_log,
+    log_trajectory_metrics_per_group,
+    log_trajectory_ranking_table,
+)
+from .plotting_utils import trajectory_error_histograms
+from .trajectory_metrics import (
+    per_step_deltas, summarize_method_metrics, combined_zscore_ranking,
+)
+
+bcheck = "✔"
+
+
+def collect_reference_trajectories(
+    odset_dict: dict, geom_ref_opt_lot: str, logger: logging.Logger,
+) -> dict:
+    """Pull each system's reference optimization trajectory.
+
+    A fetch failure on one system (e.g. qcportal cache OverflowError on
+    a record with corrupted property values) is logged with a prominent
+    warning and the system is skipped — other systems still get analysed.
+    Matches the defense-in-depth pattern of skipping a single bad record
+    rather than aborting the whole workflow.
+    """
+    out = {}
+    for struct_name, odset in odset_dict.items():
+        try:
+            steps = qcf.get_optimization_trajectory(
+                odset, struct_name, geom_ref_opt_lot,
+            )
+        except Exception as exc:
+            logger.warning("")
+            logger.warning(
+                f"  !! WARNING: {struct_name}: trajectory fetch failed "
+                f"({type(exc).__name__}: {exc})."
+            )
+            logger.warning(
+                f"  !!          This system will be EXCLUDED from the "
+                f"trajectory benchmark; eq-geometry RMSD is unaffected."
+            )
+            logger.warning("")
+            continue
+        if not steps:
+            logger.warning(
+                f"  No reference trajectory for {struct_name} at "
+                f"{geom_ref_opt_lot} — skipping system."
+            )
+            continue
+        if any(s["gradient_hartree_per_bohr"] is None for s in steps):
+            logger.warning(
+                f"  Reference trajectory for {struct_name} missing gradient "
+                f"on some steps — skipping system."
+            )
+            continue
+        out[struct_name] = steps
+        logger.info(
+            f"  {struct_name}: {len(steps)} reference trajectory steps."
+        )
+    return out
+
+
+def build_trajectory_sp_datasets(
+    client, traj_data: dict, all_dft_functionals: List[str],
+    program: str, dft_keyword, logger: logging.Logger,
+) -> dict:
+    """Per system: create ``<system>_trajref`` SinglepointDataset, add one
+    entry per traj step (``step_NNN``), and register one SP+gradient spec
+    per DFT functional. Idempotent — safe to re-run."""
+    traj_dsets = {}
+    kw = dft_keyword if isinstance(dft_keyword, dict) else {}
+    for struct_name, steps in traj_data.items():
+        ds_name = f"{struct_name}_trajref"
+        ds_sp = qcf.get_or_create_singlepoint_dataset(client, ds_name)
+
+        entries = [
+            (f"step_{i:03d}", step["molecule"])
+            for i, step in enumerate(steps)
+        ]
+        qcf.add_singlepoint_entries(ds_sp, entries)
+
+        for functional in all_dft_functionals:
+            method, basis = functional.split("_", 1)
+            qcf.add_gradient_spec(
+                ds_sp,
+                spec_name=functional,
+                method=method,
+                basis=basis,
+                program=program,
+                keywords=kw,
+                description=(
+                    f"SP+gradient on ref trajectory geometry "
+                    f"for {functional}"
+                ),
+            )
+        traj_dsets[struct_name] = ds_sp
+        logger.info(
+            f"  {struct_name}: dataset '{ds_name}' "
+            f"({len(entries)} entries, {len(all_dft_functionals)} specs)"
+        )
+    return traj_dsets
+
+
+def submit_trajectory_singlepoints(
+    traj_dsets: dict, all_dft_functionals: List[str],
+    tag: str, logger: logging.Logger,
+):
+    """Submit all (entry × spec) SP+gradient pairs.
+
+    Assumes ``all_dft_functionals`` is already lowercased (per the
+    convention applied at the top of ``run_trajectory_analysis``,
+    matching be_hess / energy_benchmark / sampling).
+    """
+    inserted = existing = 0
+    for ds_sp in traj_dsets.values():
+        meta = qcf.submit_singlepoints_in_dataset(
+            ds_sp, spec_names=all_dft_functionals, tag=tag,
+        )
+        inserted += getattr(meta, "n_inserted", 0)
+        existing += getattr(meta, "n_existing", 0)
+    logger.info(
+        f"  Submitted {inserted} new SP+gradient computations "
+        f"({existing} already existed) to tag '{tag}'."
+    )
+    return inserted, existing
+
+
+def wait_for_trajectory_completion(
+    traj_dsets: dict, all_dft_functionals: List[str],
+    wait_interval: int, logger: logging.Logger,
+):
+    """Poll until every (system × entry × spec) trajectory SP is terminal.
+
+    Assumes ``all_dft_functionals`` is already lowercased.
+    """
+    while True:
+        complete = incomplete = error = 0
+        for ds_sp in traj_dsets.values():
+            for entry_name in ds_sp.entry_names:
+                for spec_key in all_dft_functionals:
+                    record = ds_sp.get_record(entry_name, spec_key)
+                    if record is None:
+                        continue
+                    if is_complete(record.status):
+                        complete += 1
+                    elif is_incomplete(record.status):
+                        incomplete += 1
+                    elif is_error(record.status):
+                        error += 1
+        if incomplete == 0:
+            logger.info(
+                f"  Traj SP: Complete: {complete}, Error: {error} {bcheck}"
+            )
+            return complete, error
+        logger.info(
+            f"  Traj SP: {complete} done, {incomplete} running, {error} err"
+        )
+        logger.info(f"  Waiting {wait_interval}s before rechecking...")
+        time.sleep(wait_interval)
+
+
+def compute_per_method_trajectory_metrics(
+    traj_data: dict, traj_dsets: dict, all_dft_functionals: List[str],
+    logger: logging.Logger,
+):
+    """For each functional, aggregate per-step deltas across systems and
+    return ``(metrics, raw_deltas)``.
+
+    ``metrics`` is a dict ``{functional → summarised MAE/RMSE numbers}``;
+    ``raw_deltas`` is a dict ``{functional → {delta_e arrays, delta_force
+    arrays}}`` for downstream plotting. Skips functionals with no
+    complete records.
+    """
+    metrics: Dict[str, dict] = {}
+    raw_deltas: Dict[str, dict] = {}
+
+    for functional in all_dft_functionals:
+        per_system = []
+        skipped_systems = 0
+
+        for struct_name, steps in traj_data.items():
+            ds_sp = traj_dsets.get(struct_name)
+            if ds_sp is None:
+                continue
+
+            ref_e, ref_g, dft_e, dft_g = [], [], [], []
+            n_atoms = None
+            for i, step in enumerate(steps):
+                entry_name = f"step_{i:03d}"
+                de, dg = qcf.fetch_sp_energy_gradient(
+                    ds_sp, entry_name, functional,
+                )
+                if de is None or dg is None:
+                    continue
+                if (step["energy_hartree"] is None
+                        or step["gradient_hartree_per_bohr"] is None):
+                    continue
+                if n_atoms is None:
+                    n_atoms = len(step["molecule"].symbols)
+                ref_e.append(step["energy_hartree"])
+                ref_g.append(step["gradient_hartree_per_bohr"])
+                dft_e.append(de)
+                dft_g.append(dg)
+
+            if not ref_e:
+                skipped_systems += 1
+                continue
+
+            per_system.append(per_step_deltas(
+                np.asarray(ref_e), np.asarray(ref_g),
+                np.asarray(dft_e), np.asarray(dft_g),
+                n_atoms=n_atoms,
+            ))
+
+        if not per_system:
+            logger.warning(
+                f"  {functional}: no complete trajectory data — excluded."
+            )
+            continue
+
+        metrics[functional] = summarize_method_metrics(per_system)
+        raw_deltas[functional] = {
+            "delta_e_per_atom_meV": np.concatenate(
+                [d["delta_e_per_atom_meV"] for d in per_system]
+            ),
+            "delta_force_meV_per_A": np.concatenate(
+                [d["delta_force_meV_per_A"].ravel() for d in per_system]
+            ),
+        }
+        if skipped_systems:
+            logger.info(
+                f"  {functional}: {skipped_systems} systems had no complete "
+                "records."
+            )
+    return metrics, raw_deltas
+
+
+def build_ranking_df(
+    rmsd_df: pd.DataFrame, traj_metrics: dict,
+    dft_geom_functionals: dict, score_weights: dict,
+):
+    """Merge eq-RMSD and trajectory force-RMSD keyed by functional and
+    compute the z-score combined ranking.
+
+    ``rmsd_df`` columns are mixed-case (built by ``compare_all_rmsd``);
+    ``traj_metrics`` keys are lowercase (the workflow convention). We
+    look up in mixed case but emit lowercase keys so the intersection
+    with ``traj_metrics`` is well-defined.
+
+    Energy is not part of the geom_benchmark ranking — absolute energies
+    aren't meaningful for geometry quality. ``rmsd_energy`` stays
+    available in ``traj_metrics`` as a side-channel diagnostic.
+    """
+    rmsd_eq = {}
+    for group, funcs in dft_geom_functionals.items():
+        for f in funcs:
+            col = f"{group}_{f}"
+            if col in rmsd_df.columns:
+                mean_val = float(rmsd_df[col].dropna().mean())
+                if not np.isnan(mean_val):
+                    rmsd_eq[f.lower()] = mean_val
+
+    common = sorted(set(rmsd_eq.keys()) & set(traj_metrics.keys()))
+    if not common:
+        return None
+
+    metrics_df = pd.DataFrame(
+        [
+            {
+                "rmsd_eq": rmsd_eq[m],
+                "rmsd_force": traj_metrics[m]["rmsd_force"],
+            }
+            for m in common
+        ],
+        index=common,
+    )
+    ranking_df = combined_zscore_ranking(metrics_df, score_weights)
+    return ranking_df.join(metrics_df, how="left")
+
+
+def run_trajectory_analysis(
+    *, config, client, odset_dict: dict, geom_ref_opt_lot: str,
+    all_dft_functionals: List[str], dft_geom_functionals: dict,
+    dft_program: str, dft_keyword, dft_tag: str,
+    rmsd_df: pd.DataFrame, res_folder: Path, logger: logging.Logger,
+):
+    """Top-level driver for the trajectory benchmark.
+
+    Pulls each system's reference trajectory, builds a per-system
+    ``SinglepointDataset``, registers one SP+gradient spec per DFT
+    functional, submits, waits for completion, computes per-method
+    MAE/RMSE of energy and forces vs the reference, builds the combined
+    z-score-weighted ranking, logs the BENCHMARK-RESULTS-style per-group
+    tables + the ranking table, and writes the JSON + plot artifacts
+    next to the existing geom_benchmark outputs.
+
+    Returns ``(ranking_df, raw_deltas)``.
+    """
+    # Convention used by be_hess / energy_benchmark / sampling: lowercase
+    # spec names once at the workflow entry, then pass through untouched.
+    # qcf-astrochem stores specs lowercase and lookups are case-sensitive.
+    # dft_geom_functionals stays mixed-case here because compare_all_rmsd
+    # built rmsd_df with mixed-case column names; build_ranking_df does
+    # the lookup in mixed case and emits lowercase keys.
+    all_dft_functionals = [s.lower() for s in all_dft_functionals]
+    padded_log(logger, "Trajectory analysis (DFT vs reference)")
+
+    logger.info("\nCollecting reference trajectories…")
+    traj_data = collect_reference_trajectories(
+        odset_dict, geom_ref_opt_lot, logger,
+    )
+    if not traj_data:
+        logger.warning(
+            "\n  No usable reference trajectories — skipping trajectory "
+            "analysis.\n"
+        )
+        return None, {}
+
+    logger.info("\nBuilding trajectory singlepoint datasets…")
+    traj_dsets = build_trajectory_sp_datasets(
+        client, traj_data, all_dft_functionals,
+        dft_program, dft_keyword, logger,
+    )
+
+    logger.info(
+        f"\nSubmitting trajectory SP+gradient computations to tag "
+        f"'{dft_tag}'…"
+    )
+    submit_trajectory_singlepoints(
+        traj_dsets, all_dft_functionals, dft_tag, logger,
+    )
+
+    logger.info("\nWaiting for trajectory SPs to complete…")
+    wait_for_trajectory_completion(
+        traj_dsets, all_dft_functionals, wait_interval=200, logger=logger,
+    )
+
+    logger.info("\nComputing per-method trajectory metrics…")
+    traj_metrics, raw_deltas = compute_per_method_trajectory_metrics(
+        traj_data, traj_dsets, all_dft_functionals, logger,
+    )
+
+    ranking_df = build_ranking_df(
+        rmsd_df, traj_metrics, dft_geom_functionals, config.score_weights,
+    )
+
+    padded_log(logger, "TRAJECTORY BENCHMARK RESULTS")
+    log_trajectory_metrics_per_group(
+        logger, traj_metrics, dft_geom_functionals, ranking_df,
+    )
+
+    padded_log(logger, "Combined ranking (z-score weighted)")
+    log_trajectory_ranking_table(
+        logger, ranking_df, score_weights=config.score_weights,
+    )
+
+    folder_path_json = res_folder / "json_data"
+    folder_path_json.mkdir(parents=True, exist_ok=True)
+    metrics_json = {
+        m: {k: v for k, v in d.items()}
+        for m, d in traj_metrics.items()
+    }
+    (folder_path_json / "results_trajectory_metrics.json").write_text(
+        json.dumps(metrics_json, indent=4, default=str)
+    )
+    if ranking_df is not None:
+        ranking_df.to_json(
+            str(folder_path_json / "results_trajectory_ranking.json"),
+        )
+    logger.info(
+        f"\n  Trajectory metrics + ranking written to "
+        f"{folder_path_json}/\n"
+    )
+
+    if raw_deltas:
+        folder_path_plots = res_folder / "plots"
+        folder_path_plots.mkdir(parents=True, exist_ok=True)
+        try:
+            trajectory_error_histograms(
+                raw_deltas, mol_name=config.molecule,
+                plot_path=str(folder_path_plots),
+                ranking_df=ranking_df,
+            )
+            logger.info(
+                f"  Trajectory error histograms written to "
+                f"{folder_path_plots}/\n"
+            )
+        except Exception as exc:
+            logger.warning(
+                f"  Histogram plotting failed: {exc} — "
+                f"metrics are still available in json_data/"
+            )
+
+    return ranking_df, raw_deltas

--- a/beep/core/zpve.py
+++ b/beep/core/zpve.py
@@ -162,11 +162,19 @@ def _harmonic_analysis(hess, geom, mass, project_trans=True, project_rot=True):
     # Characteristic vibrational temperature
     theta_vib = np.abs(omega.real) * 100.0 * _C * _H / _KB  # [K]
 
+    # Cartesian un-mass-weighted eigenvectors, reshaped so a mode is a
+    # (n_atoms, 3) array. ``modes_cart[i]`` is the Cartesian displacement
+    # pattern of mode i (units: Å·amu^(-1/2), but only the direction is
+    # used downstream — the displacement-amplitude module normalises to a
+    # target RMS Cartesian length in Å before applying).
+    modes_cart = wL.T.reshape(ndof, nat, 3)
+
     vibinfo = {
         "omega": Datum("omega", "cm^-1", omega),
         "mu": Datum("mu", "u", mu),
         "TRV": SimpleNamespace(data=trv),
         "theta_vib": Datum("theta_vib", "K", theta_vib),
+        "modes_cart": SimpleNamespace(data=modes_cart),
     }
     return vibinfo
 

--- a/beep/models/__init__.py
+++ b/beep/models/__init__.py
@@ -12,3 +12,4 @@ from .extract import ExtractConfig
 from .pre_exp import PreExpConfig
 from .geom_benchmark import GeomBenchmarkConfig
 from .energy_benchmark import EnergyBenchmarkConfig
+from .nm_sampling import NmSamplingConfig

--- a/beep/models/energy_benchmark.py
+++ b/beep/models/energy_benchmark.py
@@ -28,6 +28,22 @@ class EnergyBenchmarkConfig(BaseModel):
     tag_cbs: str = Field(..., description="Queue tag for CBS extrapolation tasks")
     use_initial_reference_geometry: bool = Field(False, description="Use initial (unoptimized) reference geometry")
     custom_dft_functionals: List[str] = Field([], description="Additional DFT functionals to include in the benchmark (e.g. ['RPBE-D4', 'BLYP-D4'])")
+    gcp_correction: bool = Field(
+        False,
+        description=(
+            "If True, submit a standalone gCP (Kruse & Grimme 2012) "
+            "correction at dft/def2-tzvp for every unique molecule used in "
+            "the binding-energy stoichiometries. The workflow combines it "
+            "post-hoc with the bare DFT energies at extract time to "
+            "produce a gCP-corrected BE column. Applied only when "
+            "be_basis == def2-tzvp and only to functionals listed in "
+            "core.dft_functionals.gcp_compatible_functionals() — -3c "
+            "composites (gCP already baked in), double hybrids (gCP not "
+            "parametrized), and HF-D3BJ (separate gCP parameter set) are "
+            "skipped. For any other be_basis the workflow logs a warning "
+            "and silently falls back to the no-gCP path."
+        ),
+    )
 
     _lower_opt_lot = field_validator("opt_level_of_theory")(lowercase_list)
     _lower_ref_lot = field_validator("reference_geometry_level_of_theory")(lowercase_str)

--- a/beep/models/geom_benchmark.py
+++ b/beep/models/geom_benchmark.py
@@ -52,6 +52,30 @@ class GeomBenchmarkConfig(BaseModel):
     tag_dft_geometry: Optional[str] = Field(None, description="Queue tag for DFT geometry tasks")
     use_initial_reference_geometry: bool = Field(False, description="Use initial (unoptimized) reference geometry")
     bsse_test: Optional[BSSETestConfig] = Field(None, description="Optional BSSE/dispersion test on a single functional")
+    trajectory_analysis: bool = Field(
+        True,
+        description=(
+            "If True (default), evaluate each DFT functional via SP+gradient "
+            "at every geometry along the reference optimization trajectory "
+            "and report RMSD of the per-component force (meV/Å) vs the "
+            "reference. Combined with the equilibrium-geometry RMSD via a "
+            "z-score-weighted score (see ``score_weights``). Absolute "
+            "energies are not used here — use the energy_benchmark workflow "
+            "for relative-energy comparison. Set to False to keep the "
+            "legacy eq-geometry-only behaviour."
+        ),
+    )
+    score_weights: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "rmsd_eq": 1.0,
+            "rmsd_force": 1.0,
+        },
+        description=(
+            "Weights for the combined z-score ranking when "
+            "trajectory_analysis is enabled. Keys: rmsd_eq, rmsd_force. "
+            "Default: equal weighting."
+        ),
+    )
 
     @field_validator("reference_geometry_level_of_theory")
     @classmethod

--- a/beep/models/nm_sampling.py
+++ b/beep/models/nm_sampling.py
@@ -1,0 +1,157 @@
+"""Normal-mode displacement sampling workflow config."""
+from typing import Optional, Literal, List, Dict
+from pydantic import BaseModel, Field, field_validator
+from .base import ServerConfig, lowercase_str
+
+
+class BandSpec(BaseModel):
+    """Per-band cap on the number of modes to pick + RMS Cartesian
+    displacement amplitude (Å) for each pick."""
+    cap: int = Field(
+        ..., ge=0,
+        description="Maximum number of modes to pick from this band per system",
+    )
+    amplitude_A: float = Field(
+        ..., gt=0.0,
+        description=(
+            "RMS Cartesian displacement (Å) of all atoms for a ± pair. "
+            "Each picked mode contributes 2 displaced structures at "
+            "amplitudes (+amp, -amp)."
+        ),
+    )
+
+
+def _default_bands() -> Dict[str, BandSpec]:
+    """Defaults tuned for H₂O/H₂S cluster + small-molecule binding sites.
+
+    Total per system: (3 + 2 + 1) × 2 = 12 displaced structures, +2 if the
+    lowest-frequency mode gets a second amplitude → 14 / system → ~70
+    CCSD(T) gradients on a 5-site benchmark.
+    """
+    return {
+        "intermolecular": BandSpec(cap=3, amplitude_A=0.08),
+        "bending":        BandSpec(cap=2, amplitude_A=0.05),
+        "stretching":     BandSpec(cap=1, amplitude_A=0.03),
+    }
+
+
+class NmSamplingConfig(BaseModel):
+    """Configuration for the normal-mode displacement benchmark workflow.
+
+    The workflow, per binding site:
+      1. Pulls the equilibrium geometry from an `OptimizationDataset` at
+         ``geometry_opt_lot``.
+      2. Computes a Hessian at ``hessian_lot`` (default ``hf_def2-svp``).
+      3. Diagonalises it (via qcelemental ``vibanal``), classifies each
+         normal mode as intermolecular / bending / stretching using
+         fragment-COM projection (adsorbate vs cluster).
+      4. Picks the lowest-frequency modes from each band up to its cap;
+         the N lowest-frequency selected modes get a second amplitude.
+      5. Generates ± displaced geometries at the per-band amplitude.
+      6. Submits a CCSD(T) gradient on each displaced geometry as the
+         reference, plus a DFT gradient per functional in the same
+         curated functional list ``geom_benchmark`` uses.
+      7. Reports per-functional force-RMSD vs the CCSD(T) reference,
+         per-category, with the same log layout as the trajectory
+         benchmark in ``geom_benchmark``.
+    """
+    workflow: Literal["nm_sampling"] = Field(..., description="Must be 'nm_sampling'")
+    server: ServerConfig = Field(default_factory=ServerConfig, description="QCFractal server connection settings")
+    molecule: str = Field(..., description="Name of the target adsorbate (e.g. 'H2', 'NH3', 'CFC')")
+    benchmark_structures: List[str] = Field(..., description="List of benchmark structure identifiers (e.g. ['H2_W1_0001'])")
+    small_molecule_collection: str = Field("Small_molecules", description="Name of the small-molecule (adsorbate) collection")
+    surface_model_collection: str = Field(..., description="Name of the surface-model (cluster) collection")
+    geometry_opt_lot: str = Field(
+        ...,
+        description=(
+            "Level of theory the optimised binding-site geometries live at "
+            "(method_basis, e.g. 'mpwb1k-d3bj_def2-tzvpd'). The Hessian and "
+            "all displacement gradients are evaluated at THIS geometry."
+        ),
+    )
+
+    # --- Hessian ---
+    hessian_lot: str = Field(
+        "hf_def2-svp",
+        description=(
+            "Level of theory for the Hessian. Default 'hf_def2-svp' — the "
+            "Hessian is only used as a basis for displacement directions, "
+            "so a cheap SCF is sufficient. Configurable for cases where a "
+            "richer normal-mode picture is wanted (e.g. 'pbe-d4_def2-svp')."
+        ),
+    )
+    hessian_program: str = Field("psi4", description="QC program for the Hessian")
+    hessian_keywords: Optional[Dict[str, str]] = Field(
+        None,
+        description="QC keywords passed to the Hessian SP submission (e.g. {'scf_type': 'df'})",
+    )
+    tag_hessian: Optional[str] = Field(None, description="Queue tag for the Hessian computations")
+
+    # --- Reference CCSD(T) gradients ---
+    reference_grad_lot: str = Field(
+        "ccsd(t)_aug-cc-pvtz",
+        description="Reference level of theory for the per-displacement gradients (method_basis)",
+    )
+    reference_grad_program: str = Field("psi4", description="QC program for the reference gradient")
+    reference_grad_keywords: Optional[Dict[str, str]] = Field(
+        default_factory=lambda: {"scf_type": "df", "cc_type": "df", "freeze_core": "true"},
+        description="QC keywords for the reference gradient submissions",
+    )
+    tag_reference_grad: Optional[str] = Field(None, description="Queue tag for the reference (CCSD(T)) gradients")
+
+    # --- DFT gradients ---
+    dft_program: str = Field("psi4", description="QC program for the DFT gradients")
+    dft_keyword: Optional[int] = Field(None, description="QCFractal keyword ID for DFT gradient SPs")
+    tag_dft_grad: Optional[str] = Field(None, description="Queue tag for the DFT gradient computations")
+
+    # --- Mode selection ---
+    bands: Dict[str, BandSpec] = Field(
+        default_factory=_default_bands,
+        description=(
+            "Per-band cap + amplitude. Recognised band names are "
+            "'intermolecular', 'bending', 'stretching' (matching the "
+            "labels emitted by classify_mode). Defaults give 6 modes × "
+            "2 (± per mode) = 12 displaced structures per system."
+        ),
+    )
+    inter_threshold: float = Field(
+        0.5, ge=0.0, le=1.0,
+        description=(
+            "Fragment-COM-projection ratio above which a mode is labelled "
+            "intermolecular. f_inter = inter-fragment kinetic / total "
+            "kinetic ∈ [0, 1]."
+        ),
+    )
+    bend_max_cm: float = Field(
+        1500.0, gt=0.0,
+        description=(
+            "Intramolecular modes (f_inter ≤ inter_threshold) with a "
+            "frequency below this cutoff are labelled 'bending'; above "
+            "this cutoff, 'stretching'."
+        ),
+    )
+    freq_max_imag_cm: float = Field(
+        50.0, ge=0.0,
+        description=(
+            "Maximum allowed magnitude (cm⁻¹) of an imaginary frequency "
+            "for a mode to be eligible for displacement. Modes with "
+            "|imag| above this are dropped (genuine saddle-point directions)."
+        ),
+    )
+    extra_amplitudes_lowest_count: int = Field(
+        1, ge=0,
+        description=(
+            "Number of lowest-frequency selected modes that get a second "
+            "amplitude. Each extra amplitude adds two displaced structures "
+            "(+, −) at amplitude × extra_amplitude_factor."
+        ),
+    )
+    extra_amplitude_factor: float = Field(
+        2.0, gt=0.0,
+        description="Multiplier on the band amplitude for the extra-amplitude entries",
+    )
+
+    # --- Lowercase validators (qcportal stores spec names lowercase) ---
+    _lower_geom_opt = field_validator("geometry_opt_lot")(lowercase_str)
+    _lower_hess_lot = field_validator("hessian_lot")(lowercase_str)
+    _lower_ref_lot = field_validator("reference_grad_lot")(lowercase_str)

--- a/beep/models/nm_sampling.py
+++ b/beep/models/nm_sampling.py
@@ -151,6 +151,27 @@ class NmSamplingConfig(BaseModel):
         description="Multiplier on the band amplitude for the extra-amplitude entries",
     )
 
+    # --- Run-mode controls ---
+    pre_run: bool = Field(
+        False,
+        description=(
+            "If true, run only the Hessian + normal-mode + classification "
+            "stages and exit before submitting any gradient SPs. The .molden "
+            "files and per-system mode JSONs are written so the user can "
+            "visually inspect the modes before committing the gradient budget. "
+            "Re-run with pre_run=false to continue (Hessians dedup, no recompute)."
+        ),
+    )
+    allow_imaginary_modes: bool = Field(
+        False,
+        description=(
+            "By default the workflow aborts if any system has an imaginary "
+            "frequency with magnitude above freq_max_imag_cm (saddle "
+            "geometry — displacements there would be meaningless). Set to "
+            "true to proceed anyway (e.g. for transition-state probing)."
+        ),
+    )
+
     # --- Lowercase validators (qcportal stores spec names lowercase) ---
     _lower_geom_opt = field_validator("geometry_opt_lot")(lowercase_str)
     _lower_hess_lot = field_validator("hessian_lot")(lowercase_str)

--- a/beep/workflows/be_hess.py
+++ b/beep/workflows/be_hess.py
@@ -160,9 +160,9 @@ def process_be_computation(client, logger, finished_opt_list, surf_opt_ds,
             client, rdset_name, opt_lot, smol_mol, cluster_mol, ds_opt, opt_stru, logger
         )
 
-        keyword = None
+        keyword = {"scf_initial_accelerator": "NONE"}
         if mult != 1:
-            keyword = {"reference": "uks"}
+            keyword["reference"] = "uks"
 
         padded_log(logger, f"Sending computations for {rdset_name}", padding_char="*", total_length=60)
         job_ids = qcf.compute_be_dft_energies(

--- a/beep/workflows/energy_benchmark.py
+++ b/beep/workflows/energy_benchmark.py
@@ -14,9 +14,13 @@ from ..models.energy_benchmark import EnergyBenchmarkConfig
 from ..models.base import safe_config_dump
 from ..core.logging_utils import (
     padded_log, log_formatted_list, log_progress, log_energy_mae, beep_banner,
+    log_energy_mae_per_group,
 )
 from ..core.stoichiometry import be_stoichiometry
-from ..core.dft_functionals import gga, meta_gga, hybrid_gga, lrc, meta_hybrid_gga
+from ..core.dft_functionals import (
+    gga, meta_gga, hybrid_gga, lrc, meta_hybrid_gga, non_local,
+    is_3c_method, gcp_compatible_functionals,
+)
 from ..core.plotting_utils import (
     plot_violins, plot_density_panels, plot_mean_errors, plot_ie_vs_de,
 )
@@ -359,43 +363,6 @@ def _fetch_be_molecules(odset, bench_struct, lot_geom):
     return smol_mol, surf_mol, struc_mol
 
 
-def compute_be_dft_energies_eb(client, rdset_base_name, all_dft, tag,
-                                basis="def2-tzvpd", program="psi4"):
-    logger = logging.getLogger("beep")
-    logger.info(f"Computing energies for the following stoichiometries: {' '.join(qcf.STOICH_TYPES)} (bsse = be)")
-    log_formatted_list(logger, all_dft, "Sending DFT energy computations for the following functionals:")
-
-    total_submitted = 0
-    total_existing = 0
-    for i, func in enumerate(all_dft):
-        func_submitted = 0
-        func_existing = 0
-        for stoich in qcf.STOICH_TYPES:
-            result = qcf.submit_energies(
-                client, rdset_base_name,
-                method=func, basis=basis, program=program,
-                stoich=stoich, tag=tag,
-            )
-            func_submitted += result.n_inserted
-            func_existing += result.n_existing
-        total_submitted += func_submitted
-        total_existing += func_existing
-        logger.info(f"\n{func}: Existing {func_existing}  Submitted {func_submitted}")
-        log_progress(logger, i, len(all_dft))
-
-    logger.info(f"Submitted a total of {total_submitted} DFT computations. {total_existing} are already computed")
-
-    # Collect record IDs for monitoring
-    record_ids = []
-    for stoich in qcf.STOICH_TYPES:
-        ds_name = f"{rdset_base_name}_{stoich}"
-        ds = client.get_dataset("reaction", ds_name)
-        for _, _, record in ds.iterate_records():
-            if record is not None:
-                record_ids.append(record.id)
-    return record_ids
-
-
 def run(config: EnergyBenchmarkConfig, client: FractalClient) -> None:
     logger = logging.getLogger("beep")
 
@@ -497,17 +464,61 @@ def run(config: EnergyBenchmarkConfig, client: FractalClient) -> None:
         "Hybrid GGA": hybrid_gga(),
         "Long range corrected": lrc(),
         "Meta Hybrid GGA": meta_hybrid_gga(),
+        # Cross-cutting category: every entry overlaps one of the above.
+        "Non-local (NL / VV10)": non_local(),
     }
 
     if config.custom_dft_functionals:
         dft_func["Custom"] = config.custom_dft_functionals
 
     for name, dft_f_list in dft_func.items():
-        padded_log(logger, f"Sending computations for {name} functionals with a {config.be_basis} basis")
-        dft_ids = compute_be_dft_energies_eb(
-            client, rdset_base, dft_f_list, basis=config.be_basis, program="psi4", tag=config.tag_be,
+        padded_log(
+            logger,
+            f"Sending computations for {name} functionals with a {config.be_basis} basis",
+        )
+        # Build the LOT strings expected by the shared submission helper
+        # (canonical "<method>_<basis>" form), then route through
+        # qcf.compute_be_dft_energies — the same separated-pair submission
+        # path be_hess uses (bare DFT + bare dispersion specs that
+        # fetch_reaction_values recombines into composite columns).
+        dft_lots = [f"{func}_{config.be_basis}" for func in dft_f_list]
+        dft_ids = qcf.compute_be_dft_energies(
+            client, rdset_base, dft_lots,
+            tag=config.tag_be, program="psi4", logger=logger,
+            keyword=None,
         )
         qcf.check_jobs_status(client, dft_ids, logger)
+
+    # Optional gCP correction (Kruse & Grimme 2012) — standalone mctc-gcp SP
+    # per unique molecule. Combined post-hoc with bare DFT energies at extract
+    # time. Only meaningful for be_basis = def2-tzvp (the single basis we
+    # support for gCP in this workflow). For any other basis we warn and
+    # silently fall back to the no-gCP path.
+    if config.gcp_correction:
+        if config.be_basis != "def2-tzvp":
+            logger.warning(
+                f"\n  gcp_correction enabled but be_basis = {config.be_basis} — "
+                "mctc-gcp is only parametrized for def2-tzvp in this workflow. "
+                "Falling back to the no-gCP path."
+            )
+        else:
+            padded_log(logger, "Submitting gCP corrections (mctc-gcp / dft/def2-tzvp)")
+            ds_nocp = client.get_dataset("reaction", f"{rdset_base}_be_nocp")
+            unique_mol_ids = set()
+            for entry in ds_nocp.iterate_entries():
+                for s in entry.stoichiometries:
+                    unique_mol_ids.add(s.molecule.id)
+            unique_mol_ids = list(unique_mol_ids)
+            logger.info(
+                f"  Submitting gCP for {len(unique_mol_ids)} unique molecules"
+            )
+            meta, gcp_record_ids = qcf.submit_gcp_corrections(
+                client, unique_mol_ids, tag=config.tag_be,
+            )
+            logger.info(
+                f"  Existing: {meta.n_existing}  Submitted: {meta.n_inserted}"
+            )
+            qcf.check_jobs_status(client, gcp_record_ids, logger)
 
     padded_log(logger, "Retriving energies from ReactionDataset")
     df_be = qcf.fetch_reaction_values(client, rdset_base, stoich="bsse").dropna(axis=1)
@@ -566,12 +577,105 @@ def run(config: EnergyBenchmarkConfig, client: FractalClient) -> None:
         logger.warning(f"Plotting failed: {e}. Data files are saved, plots can be regenerated.")
 
     padded_log(logger, "BINDING ENERGY BENCHMARK RESULTS", padding_char=gear)
-    padded_log(logger, "BINDING ENERGY MAE")
-    log_energy_mae(logger, df_be_ae)
-    padded_log(logger, "INTERACTION ENERGY MAE")
-    log_energy_mae(logger, df_ie_ae)
-    padded_log(logger, "DEFORMATION ENERGY MAE")
-    log_energy_mae(logger, df_de_ae)
+    padded_log(logger, "BINDING ENERGY MAE (BSSE / Boys-Bernardi)")
+    log_energy_mae_per_group(logger, df_be_ae, dft_func)
+    logger.info("")
+    logger.info("  Note — Interaction-energy (IE) and deformation-energy (DE)")
+    logger.info("         breakdowns are not shown in this summary. Per-method")
+    logger.info("         values and errors vs the CCSD(T)/CBS reference are")
+    logger.info("         available in:")
+    logger.info("")
+    logger.info("           IE :  json_data/IE_DFT.json")
+    logger.info("                 json_data/IE_AE_DFT.json   (absolute error)")
+    logger.info("                 json_data/IE_RE_DFT.json   (relative error)")
+    logger.info("")
+    logger.info("           DE :  json_data/DE_DFT.json")
+    logger.info("                 json_data/DE_AE_DFT.json   (absolute error)")
+    logger.info("                 json_data/DE_RE_DFT.json   (relative error)")
+    logger.info("")
+
+    # Optional gCP-corrected BE block — runs only when gcp_correction was
+    # actually applied (toggle on AND basis matched). Combines the bare
+    # no-CP DFT binding energies with the standalone gCP correction term
+    # for each entry (Δgcp = gcp(complex) − gcp(A) − gcp(B)), restricted
+    # to the gcp-compatible functional pool.
+    if config.gcp_correction and config.be_basis == "def2-tzvp":
+        padded_log(logger, "gCP-CORRECTED BINDING ENERGY", padding_char=gear)
+
+        # Walk the be_nocp dataset to get the (entry → stoichiometry) map
+        # and collect every unique molecule id.
+        ds_nocp = client.get_dataset("reaction", f"{rdset_base}_be_nocp")
+        entry_stoichs: Dict[str, List[Tuple[float, int]]] = {}
+        unique_mol_ids = set()
+        for entry in ds_nocp.iterate_entries():
+            entry_stoichs[entry.name] = [
+                (s.coefficient, s.molecule.id) for s in entry.stoichiometries
+            ]
+            for s in entry.stoichiometries:
+                unique_mol_ids.add(s.molecule.id)
+
+        gcp_map = qcf.fetch_gcp_corrections(client, list(unique_mol_ids))
+        logger.info(
+            f"  Fetched gCP corrections for {len(gcp_map)}/{len(unique_mol_ids)} "
+            f"molecules."
+        )
+
+        # Hartree → kcal/mol, matching what fetch_reaction_values returns
+        hartree_to_kcal = qcel.constants.conversion_factor("hartree", "kcal/mol")
+        delta_gcp_kcal = {}
+        for entry, stoichs in entry_stoichs.items():
+            try:
+                delta_h = sum(coef * gcp_map[mid] for coef, mid in stoichs)
+            except KeyError:
+                continue  # incomplete gCP coverage for this entry — skip
+            delta_gcp_kcal[entry] = delta_h * hartree_to_kcal
+
+        # Restrict to gcp-compatible methods (case-insensitive method match)
+        compat_lower = {m.lower() for m in gcp_compatible_functionals()}
+        df_be_nocp = qcf.fetch_reaction_values(
+            client, rdset_base, stoich="be_nocp",
+        ).dropna(axis=1)
+
+        # df_be_nocp column convention: "<method>/<basis>" (slash separator
+        # comes from fetch_reaction_values' label-formatting).
+        gcp_cols = [
+            col for col in df_be_nocp.columns
+            if col.rsplit("/", 1)[0] in compat_lower
+        ]
+
+        if not gcp_cols or not delta_gcp_kcal:
+            logger.warning(
+                "  No gCP-corrected columns to report "
+                "(missing matches between method list and reaction columns)."
+            )
+        else:
+            df_be_gcp = df_be_nocp[gcp_cols].copy()
+            for entry in df_be_gcp.index:
+                if entry in delta_gcp_kcal:
+                    df_be_gcp.loc[entry] = (
+                        df_be_gcp.loc[entry] + delta_gcp_kcal[entry]
+                    )
+
+            # Persist alongside the existing BE_DFT.json
+            df_be_gcp.to_json(folder_path_json / "BE_gcp_DFT.json", orient="index")
+            logger.info(
+                f"  Saved gCP-corrected BE in BE_gcp_DFT.json "
+                f"({len(gcp_cols)} methods × {len(df_be_gcp.index)} entries) "
+                f"{bcheck}"
+            )
+
+            df_be_gcp_ae, df_be_gcp_re = get_errors_dataframe(
+                df_be_gcp, ref_df["BE"].to_dict(),
+            )
+            df_be_gcp_ae.to_json(
+                folder_path_json / "BE_gcp_AE_DFT.json", orient="index",
+            )
+            df_be_gcp_re.to_json(
+                folder_path_json / "BE_gcp_RE_DFT.json", orient="index",
+            )
+
+            padded_log(logger, "gCP-CORRECTED BINDING ENERGY MAE")
+            log_energy_mae_per_group(logger, df_be_gcp_ae, dft_func)
 
     logger.removeHandler(file_handler)
     file_handler.close()

--- a/beep/workflows/geom_benchmark.py
+++ b/beep/workflows/geom_benchmark.py
@@ -22,6 +22,7 @@ from ..core.dft_functionals import (
 )
 from ..core.plotting_utils import rmsd_histograms
 from ..core.benchmark_utils import create_benchmark_dataset_dict, compute_rmsd
+from ..core.trajectory_workflow import run_trajectory_analysis
 from ..adapters import qcfractal_adapter as qcf
 from ..adapters.qcfractal_adapter import FractalClient, is_complete, is_incomplete, is_error, status_label
 
@@ -796,6 +797,22 @@ def run(config: GeomBenchmarkConfig, client: FractalClient) -> None:
     folder_path_plots.mkdir(parents=True, exist_ok=True)
 
     rmsd_histograms(rmsd_df, smol_name, str(folder_path_plots))
+
+    # Trajectory analysis: SP+gradient at every reference-trajectory geometry,
+    # MAE/RMSE of E and forces vs reference, combined z-score ranking.
+    # Runs AFTER BENCHMARK RESULTS so the eq-RMSD per-group output is the
+    # first benchmark summary the user sees; the trajectory benchmark
+    # appears immediately below in the same per-group style.
+    if config.trajectory_analysis:
+        run_trajectory_analysis(
+            config=config, client=client, odset_dict=odset_dict,
+            geom_ref_opt_lot=geom_ref_opt_lot,
+            all_dft_functionals=all_dft_functionals,
+            dft_geom_functionals=dft_geom_functionals,
+            dft_program=dft_program, dft_keyword=dft_keyword,
+            dft_tag=dft_tag, rmsd_df=rmsd_df,
+            res_folder=res_folder, logger=logger,
+        )
 
     padded_log(
         logger,

--- a/beep/workflows/nm_sampling.py
+++ b/beep/workflows/nm_sampling.py
@@ -1,0 +1,120 @@
+"""Normal-mode displacement benchmark workflow.
+
+Entry point for ``beep --config <nm_sampling.json>``. Sets up logging
+and the output folder, resolves the optimisation datasets for the
+target molecule + surface model + benchmark binding sites, and hands
+control to the orchestrator in
+:mod:`beep.core.nm_sampling_workflow`.
+
+The actual physics + orchestration lives in:
+  - :mod:`beep.core.normal_mode_sampling` — classification, selection,
+    displacement math.
+  - :mod:`beep.core.nm_sampling_workflow` — chain Hessian → vibanal →
+    displacement → SP+gradient → metrics.
+  - :mod:`beep.adapters.qcfractal_adapter` — QCFractal I/O (``submit_hessians``,
+    ``fetch_normal_modes``, the ``SinglepointDataset`` helpers).
+"""
+import logging
+from pathlib import Path
+
+from ..models.nm_sampling import NmSamplingConfig
+from ..models.base import safe_config_dump
+from ..core.logging_utils import padded_log, beep_banner
+from ..core.dft_functionals import (
+    geom_hmgga_dz, geom_hmgga_tz, geom_gga_dz, geom_gga_tz, geom_sqm_mb,
+)
+from ..core.benchmark_utils import create_benchmark_dataset_dict
+from ..core.nm_sampling_workflow import run_nm_sampling
+from ..adapters import qcfractal_adapter as qcf
+from ..adapters.qcfractal_adapter import FractalClient
+
+
+mia0911 = "☆"
+gear = "⚙"
+
+welcome_msg = beep_banner(
+    "NM-Sampling",
+    tagline="Move along the soft modes; let CCSD(T) keep score.",
+    authors="Stefan Vogt-Geisse",
+)
+
+
+def run(config: NmSamplingConfig, client: FractalClient) -> None:
+    logger = logging.getLogger("beep")
+
+    smol_name = config.molecule
+
+    res_folder = Path.cwd() / smol_name / "nm_sampling"
+    res_folder.mkdir(parents=True, exist_ok=True)
+
+    log_file = res_folder / f"beep_nm_sampling_{smol_name}.log"
+    file_handler = logging.FileHandler(str(log_file), mode="w")
+    file_handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(file_handler)
+
+    config_path = res_folder / f"nm_sampling_{smol_name}.json"
+    config_path.write_text(safe_config_dump(config))
+
+    logger.info(welcome_msg)
+
+    bchmk_structs = config.benchmark_structures
+    surf_dset_name = config.surface_model_collection
+    smol_dset_name = config.small_molecule_collection
+
+    padded_log(logger, "Starting BEEP NM-sampling benchmark", padding_char=gear)
+    logger.info(f"Molecule: {smol_name}")
+    logger.info(f"Surface model collection: {surf_dset_name}")
+    logger.info(f"Small molecule collection: {smol_dset_name}")
+    logger.info(f"Benchmark structures: {bchmk_structs}")
+    logger.info(f"Geometry LOT: {config.geometry_opt_lot}")
+    logger.info(f"Hessian LOT:  {config.hessian_lot}")
+    logger.info(f"Reference grad LOT: {config.reference_grad_lot}\n")
+
+    bchmk_dset_names = create_benchmark_dataset_dict(bchmk_structs)
+    qcf.check_collection_existence(client, *bchmk_dset_names.values())
+    qcf.check_collection_existence(client, smol_dset_name)
+    qcf.check_collection_existence(client, surf_dset_name)
+
+    smol_dset = qcf.get_collection(client, "OptimizationDataset", smol_dset_name)
+    odset_dict = {}
+    for bchmk_struct_name, odset_name in bchmk_dset_names.items():
+        odset_dict[bchmk_struct_name] = qcf.get_collection(
+            client, "OptimizationDataset", odset_name,
+        )
+
+    # Adsorbate atom count: pull from the small-molecule collection (same
+    # pattern as geom_benchmark.py:347-353 for the BSSE-test CP path).
+    smol_entry = smol_dset.get_entry(smol_name)
+    if smol_entry is None:
+        smol_entry = smol_dset.get_entry(smol_name.upper())
+    n_adsorbate_atoms = len(smol_entry.initial_molecule.symbols)
+    logger.info(f"Adsorbate atom count: {n_adsorbate_atoms}\n")
+
+    # Same five functional groups as geom_benchmark — the displacements
+    # are evaluated at every functional in this list.
+    dft_geom_functionals = {
+        "geom_hmgga_dz": geom_hmgga_dz(),
+        "geom_hmgga_tz": geom_hmgga_tz(),
+        "geom_gga_dz":   geom_gga_dz(),
+        "geom_gga_tz":   geom_gga_tz(),
+        "geom_sqm_mb":   geom_sqm_mb(),
+    }
+    all_dft_functionals = [
+        f for group in dft_geom_functionals.values() for f in group
+    ]
+
+    run_nm_sampling(
+        config=config, client=client, odset_dict=odset_dict,
+        all_dft_functionals=all_dft_functionals,
+        dft_geom_functionals=dft_geom_functionals,
+        n_adsorbate_atoms=n_adsorbate_atoms,
+        res_folder=res_folder, logger=logger,
+    )
+
+    padded_log(
+        logger,
+        "NM-sampling benchmark finished successfully! Hasta pronto!",
+        padding_char=mia0911,
+    )
+    logger.removeHandler(file_handler)
+    file_handler.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beep"
-version = "0.12.0"
+version = "0.13.0.dev0"
 description = "A binding energy evaluation platform and database for molecules on interstellar ice-grain mantles"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,5 +58,8 @@ def test_main_valid_dispatch(mock_connect, monkeypatch, tmp_path):
 
 
 def test_workflow_models_keys():
-    expected = {"sampling", "be_hess", "extract", "pre_exp", "geom_benchmark", "energy_benchmark"}
+    expected = {
+        "sampling", "be_hess", "extract", "pre_exp",
+        "geom_benchmark", "energy_benchmark", "nm_sampling",
+    }
     assert set(WORKFLOW_MODELS.keys()) == expected

--- a/tests/test_normal_mode_sampling.py
+++ b/tests/test_normal_mode_sampling.py
@@ -1,4 +1,5 @@
 """Tests for beep/core/normal_mode_sampling.py."""
+import json
 import numpy as np
 import pytest
 
@@ -7,6 +8,8 @@ from beep.core.normal_mode_sampling import (
     select_modes,
     displace_along_mode,
     extract_normal_modes_from_hessian_record,
+    write_molden,
+    write_modes_json,
     _BOHR_TO_A,
 )
 
@@ -15,59 +18,110 @@ from beep.core.normal_mode_sampling import (
 # classify_mode
 # ---------------------------------------------------------------------------
 
-def _ten_atom_masses(n_ads=2):
-    """Cluster of 8 oxygens + adsorbate of `n_ads` hydrogens (rough proxy)."""
-    return np.array([16.0] * 8 + [1.0] * n_ads)
+def _ten_atom_setup(n_ads=2):
+    """Cluster of 8 oxygens (in a cube) + adsorbate of `n_ads` hydrogens.
+
+    Returns (masses, positions). Adsorbate hydrogens sit on a small bond
+    along the x-axis at +/- 0.5 Å around (4, 0, 0), well separated from
+    the cluster — a rough proxy for a small molecule on a water cluster.
+    """
+    masses = np.array([16.0] * 8 + [1.0] * n_ads)
+    # 8-atom cubic cluster of oxygens at the unit-cube corners.
+    grid = np.array([[x, y, z]
+                     for x in (-1.0, +1.0)
+                     for y in (-1.0, +1.0)
+                     for z in (-1.0, +1.0)])
+    # 2-atom adsorbate H–H along x at (4, 0, 0).
+    ads = np.array([[3.5, 0.0, 0.0], [4.5, 0.0, 0.0]])[:n_ads]
+    positions = np.vstack([grid, ads])
+    return masses, positions
 
 
 def test_classify_intermolecular_pure_com_translation():
     """Adsorbate translates uniformly +z, cluster stationary → intermolecular."""
-    masses = _ten_atom_masses(n_ads=2)
+    masses, positions = _ten_atom_setup(n_ads=2)
     mode = np.zeros((10, 3))
     mode[8:10, 2] = 1.0  # both adsorbate atoms move +z
-    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=2,
                           frequency_cm=200.0) == "intermolecular"
 
 
-def test_classify_stretching_intramolecular_bond_oscillation():
-    """Adsorbate H–H bond stretch, cluster stationary, high-freq → stretching."""
-    masses = _ten_atom_masses(n_ads=2)
+def test_classify_intermolecular_libration():
+    """Adsorbate rotates about its own COM (libration), cluster stationary.
+
+    This is the failure mode of the COM-displacement-only classifier:
+    the fragment COM does not move, but every atom in the fragment does.
+    A rigid-body classifier captures the rotational KE and labels this
+    intermolecular.
+    """
+    masses, positions = _ten_atom_setup(n_ads=2)
+    # Adsorbate at (3.5, 0, 0) and (4.5, 0, 0): COM at (4, 0, 0).
+    # Rotation about z (perpendicular to the bond) → atom 8 moves +y,
+    # atom 9 moves -y. Net COM displacement = 0; angular momentum
+    # about the z-axis is non-zero.
     mode = np.zeros((10, 3))
-    mode[8, 0] = +1.0   # H₁ moves +x
-    mode[9, 0] = -1.0   # H₂ moves −x  (net COM motion ~ 0)
-    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+    mode[8, 1] = +1.0
+    mode[9, 1] = -1.0
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=2,
+                          frequency_cm=120.0) == "intermolecular"
+
+
+def test_classify_stretching_intramolecular_bond_oscillation():
+    """Adsorbate H–H bond stretch, cluster stationary, high-freq → stretching.
+
+    The bond axis is along x, both H atoms move in ±x — pure stretch with
+    no COM translation and no angular momentum (radial vs ρ — cross is 0).
+    """
+    masses, positions = _ten_atom_setup(n_ads=2)
+    mode = np.zeros((10, 3))
+    mode[8, 0] = +1.0   # H₁ moves +x (along bond, outward)
+    mode[9, 0] = -1.0   # H₂ moves −x  (outward) → no COM motion, no rotation
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=2,
                           frequency_cm=4000.0) == "stretching"
 
 
 def test_classify_bending_intramolecular_low_freq():
-    """Same antisymmetric motion at low frequency → bending (intramolecular)."""
-    masses = _ten_atom_masses(n_ads=2)
+    """Stretch-like antisymmetric motion at low frequency → bending."""
+    masses, positions = _ten_atom_setup(n_ads=2)
+    # Same as the stretch test but at low frequency: both atoms move
+    # ±x along the bond axis (no rotation since v is parallel to ρ).
     mode = np.zeros((10, 3))
-    mode[8, 1] = +1.0
-    mode[9, 1] = -1.0
-    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+    mode[8, 0] = +1.0
+    mode[9, 0] = -1.0
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=2,
                           frequency_cm=800.0) == "bending"
 
 
 def test_classify_degenerate_n_ads_falls_back_to_freq():
     """If n_adsorbate_atoms is 0 or full system, f_inter is zero, so
     only frequency drives the classification."""
-    masses = _ten_atom_masses(n_ads=2)
+    masses, positions = _ten_atom_setup(n_ads=2)
     mode = np.ones((10, 3))
     # n_ads=0 → degenerate, falls through to frequency cut
-    assert classify_mode(mode, masses, n_adsorbate_atoms=0,
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=0,
                           frequency_cm=500.0) == "bending"
-    assert classify_mode(mode, masses, n_adsorbate_atoms=0,
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=0,
                           frequency_cm=3000.0) == "stretching"
 
 
 def test_classify_zero_mode_returns_bending_low_freq():
     """A zero mode (e.g. spurious near-TR remnant) shouldn't blow up."""
-    masses = _ten_atom_masses(n_ads=2)
+    masses, positions = _ten_atom_setup(n_ads=2)
     mode = np.zeros((10, 3))
     # zero kinetic → f_inter forced to 0 → falls through to frequency
-    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=2,
                           frequency_cm=100.0) == "bending"
+
+
+def test_classify_single_atom_adsorbate_handled():
+    """One-atom adsorbate (e.g. He on water) has zero inertia tensor —
+    rigid-body kinetic must still evaluate without raising."""
+    masses, positions = _ten_atom_setup(n_ads=1)
+    mode = np.zeros((9, 3))
+    mode[8, 2] = 1.0  # the lone adsorbate atom moves +z
+    # Pure intermolecular translation of the monatomic adsorbate.
+    assert classify_mode(mode, masses, positions, n_adsorbate_atoms=1,
+                          frequency_cm=80.0) == "intermolecular"
 
 
 # ---------------------------------------------------------------------------
@@ -253,3 +307,67 @@ def test_extract_normal_modes_returns_aligned_arrays():
     freqs, modes = extract_normal_modes_from_hessian_record(hess, mol, energy=0.0)
     assert freqs.shape[0] == modes.shape[0]
     assert modes.shape[1:] == (2, 3)
+
+
+# ---------------------------------------------------------------------------
+# write_molden / write_modes_json
+# ---------------------------------------------------------------------------
+
+def _two_mode_writer_fixture():
+    """Minimal 3-atom + 2-mode payload for the writer tests."""
+    symbols = ["H", "O", "H"]
+    geom_bohr = np.array([[-1.5, 0.0, 0.0], [0.0, 0.0, 0.0], [+1.5, 0.0, 0.0]])
+    freqs = np.array([1234.5 + 0j, 0 + 80j], dtype=complex)  # one real, one imag
+    modes = np.array([
+        [[0.1, 0.0, 0.0], [0.0, 0.0, 0.0], [-0.1, 0.0, 0.0]],   # symm stretch
+        [[0.0, 0.2, 0.0], [0.0, 0.0, 0.0], [0.0, -0.2, 0.0]],   # bend
+    ])
+    return symbols, geom_bohr, freqs, modes
+
+
+def test_write_molden_emits_required_sections(tmp_path):
+    symbols, geom, freqs, modes = _two_mode_writer_fixture()
+    out = tmp_path / "test.molden"
+    write_molden(out, symbols, geom, freqs, modes, title="unit test")
+    text = out.read_text()
+    # Required Molden sections
+    for section in ("[Molden Format]", "[Title]", "[Atoms] AU",
+                    "[FREQ]", "[FR-COORD]", "[FR-NORM-COORD]"):
+        assert section in text, f"missing section {section}"
+    # Imaginary frequency rendered as negative (Molden convention)
+    assert "-80.0000" in text, "imaginary mode not flagged with negative sign"
+    # Real frequency rendered with its value
+    assert "1234.5000" in text
+    # Both vibrations listed
+    assert "vibration 1" in text and "vibration 2" in text
+
+
+def test_write_modes_json_matches_reference_shape(tmp_path):
+    symbols, geom, freqs, modes = _two_mode_writer_fixture()
+    classes = ["stretching", "intermolecular"]
+    out = tmp_path / "modes.json"
+    write_modes_json(
+        out, symbols, geom, freqs, modes,
+        classes=classes, n_adsorbate_atoms=1,
+        level_of_theory="hf_def2-svp",
+    )
+    payload = json.loads(out.read_text())
+    # Keys mirror the validation file shape
+    for k in ("level_of_theory", "symbols", "geometry_A",
+              "adsorbate_atom_index", "modes"):
+        assert k in payload
+    assert payload["level_of_theory"] == "hf_def2-svp"
+    assert payload["symbols"] == ["H", "O", "H"]
+    # Geometry converted Bohr → Å
+    assert payload["geometry_A"][0][0] == pytest.approx(-1.5 * _BOHR_TO_A)
+    # Adsorbate convention: last n atoms
+    assert payload["adsorbate_atom_index"] == [2]
+    # Mode entries carry freq + disp + class + imaginary flag
+    assert len(payload["modes"]) == 2
+    assert payload["modes"][0]["class"] == "stretching"
+    assert payload["modes"][0]["is_imaginary"] is False
+    assert payload["modes"][1]["class"] == "intermolecular"
+    assert payload["modes"][1]["is_imaginary"] is True
+    assert payload["modes"][1]["freq_cm"] == pytest.approx(80.0)
+    # Displacement matrix shape
+    assert np.asarray(payload["modes"][0]["disp"]).shape == (3, 3)

--- a/tests/test_normal_mode_sampling.py
+++ b/tests/test_normal_mode_sampling.py
@@ -1,0 +1,255 @@
+"""Tests for beep/core/normal_mode_sampling.py."""
+import numpy as np
+import pytest
+
+from beep.core.normal_mode_sampling import (
+    classify_mode,
+    select_modes,
+    displace_along_mode,
+    extract_normal_modes_from_hessian_record,
+    _BOHR_TO_A,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_mode
+# ---------------------------------------------------------------------------
+
+def _ten_atom_masses(n_ads=2):
+    """Cluster of 8 oxygens + adsorbate of `n_ads` hydrogens (rough proxy)."""
+    return np.array([16.0] * 8 + [1.0] * n_ads)
+
+
+def test_classify_intermolecular_pure_com_translation():
+    """Adsorbate translates uniformly +z, cluster stationary → intermolecular."""
+    masses = _ten_atom_masses(n_ads=2)
+    mode = np.zeros((10, 3))
+    mode[8:10, 2] = 1.0  # both adsorbate atoms move +z
+    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+                          frequency_cm=200.0) == "intermolecular"
+
+
+def test_classify_stretching_intramolecular_bond_oscillation():
+    """Adsorbate H–H bond stretch, cluster stationary, high-freq → stretching."""
+    masses = _ten_atom_masses(n_ads=2)
+    mode = np.zeros((10, 3))
+    mode[8, 0] = +1.0   # H₁ moves +x
+    mode[9, 0] = -1.0   # H₂ moves −x  (net COM motion ~ 0)
+    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+                          frequency_cm=4000.0) == "stretching"
+
+
+def test_classify_bending_intramolecular_low_freq():
+    """Same antisymmetric motion at low frequency → bending (intramolecular)."""
+    masses = _ten_atom_masses(n_ads=2)
+    mode = np.zeros((10, 3))
+    mode[8, 1] = +1.0
+    mode[9, 1] = -1.0
+    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+                          frequency_cm=800.0) == "bending"
+
+
+def test_classify_degenerate_n_ads_falls_back_to_freq():
+    """If n_adsorbate_atoms is 0 or full system, f_inter is zero, so
+    only frequency drives the classification."""
+    masses = _ten_atom_masses(n_ads=2)
+    mode = np.ones((10, 3))
+    # n_ads=0 → degenerate, falls through to frequency cut
+    assert classify_mode(mode, masses, n_adsorbate_atoms=0,
+                          frequency_cm=500.0) == "bending"
+    assert classify_mode(mode, masses, n_adsorbate_atoms=0,
+                          frequency_cm=3000.0) == "stretching"
+
+
+def test_classify_zero_mode_returns_bending_low_freq():
+    """A zero mode (e.g. spurious near-TR remnant) shouldn't blow up."""
+    masses = _ten_atom_masses(n_ads=2)
+    mode = np.zeros((10, 3))
+    # zero kinetic → f_inter forced to 0 → falls through to frequency
+    assert classify_mode(mode, masses, n_adsorbate_atoms=2,
+                          frequency_cm=100.0) == "bending"
+
+
+# ---------------------------------------------------------------------------
+# select_modes
+# ---------------------------------------------------------------------------
+
+def _twelve_mode_setup():
+    freqs = np.array(
+        [100, 200, 300, 400, 500,        # 5 intermolecular
+         600, 700, 800,                  # 3 bending
+         2900, 3700, 3800, 3900],        # 4 stretching
+        dtype=complex,
+    )
+    classes = (
+        ["intermolecular"] * 5
+        + ["bending"] * 3
+        + ["stretching"] * 4
+    )
+    band_caps = {"intermolecular": 3, "bending": 2, "stretching": 1}
+    band_amps = {"intermolecular": 0.08, "bending": 0.05, "stretching": 0.03}
+    return freqs, classes, band_caps, band_amps
+
+
+def test_select_modes_caps_and_lowest_freq_picked():
+    freqs, classes, band_caps, band_amps = _twelve_mode_setup()
+    sel = select_modes(freqs, classes, band_caps, band_amps,
+                        extra_amplitudes_lowest_count=0)
+    # Three lowest intermolecular: indices 0, 1, 2
+    # Two lowest bending: indices 5, 6
+    # One lowest stretching: index 8
+    indices = [s[0] for s in sel]
+    assert indices == [0, 1, 2, 5, 6, 8]
+    # Amplitudes per band
+    amps = [s[1] for s in sel]
+    assert amps == [0.08, 0.08, 0.08, 0.05, 0.05, 0.03]
+    bands = [s[2] for s in sel]
+    assert bands == ["intermolecular"] * 3 + ["bending"] * 2 + ["stretching"]
+
+
+def test_select_modes_extra_amplitude_for_lowest():
+    freqs, classes, band_caps, band_amps = _twelve_mode_setup()
+    sel = select_modes(freqs, classes, band_caps, band_amps,
+                        extra_amplitudes_lowest_count=1,
+                        extra_amplitude_factor=2.0)
+    # The previous 6 entries are unchanged, the 7th is a duplicate of the
+    # lowest-frequency entry at amplitude × 2.
+    assert len(sel) == 7
+    assert sel[-1][0] == 0           # mode index of the lowest-freq entry
+    assert sel[-1][1] == pytest.approx(0.16)  # amplitude × 2
+    assert sel[-1][2] == "intermolecular"
+
+
+def test_select_modes_drops_large_imaginary():
+    """Imaginary frequency > freq_max_imag_cm is dropped; small imag kept."""
+    freqs = np.array(
+        [80j,                       # |80| > 50 → dropped (saddle direction)
+         30j,                       # |30| < 50 → kept (numerical noise)
+         100, 200, 300, 600, 700,   # five reals
+         3700,
+        ],
+        dtype=complex,
+    )
+    classes = ["intermolecular"] * 5 + ["bending", "bending", "stretching"]
+    band_caps = {"intermolecular": 3, "bending": 2, "stretching": 1}
+    band_amps = {"intermolecular": 0.08, "bending": 0.05, "stretching": 0.03}
+    sel = select_modes(freqs, classes, band_caps, band_amps,
+                        freq_max_imag_cm=50.0,
+                        extra_amplitudes_lowest_count=0)
+    indices = [s[0] for s in sel]
+    # 80j dropped; 30j kept (lowest "frequency"=0); next two reals = 100, 200
+    assert 0 not in indices            # 80j was at index 0
+    assert 1 in indices                # 30j survives
+
+
+def test_select_modes_unknown_band_is_ignored():
+    freqs = np.array([100, 200], dtype=complex)
+    classes = ["intermolecular", "unknown_band"]
+    band_caps = {"intermolecular": 3}
+    band_amps = {"intermolecular": 0.08}
+    sel = select_modes(freqs, classes, band_caps, band_amps,
+                        extra_amplitudes_lowest_count=0)
+    assert sel == [(0, 0.08, "intermolecular")]
+
+
+def test_select_modes_empty_inputs_returns_empty():
+    sel = select_modes(np.array([], dtype=complex), [], {"a": 1}, {"a": 0.1})
+    assert sel == []
+
+
+# ---------------------------------------------------------------------------
+# displace_along_mode
+# ---------------------------------------------------------------------------
+
+def test_displace_rms_equals_amplitude():
+    """The RMS Cartesian displacement of the displaced geometry equals the
+    target amplitude (in Å)."""
+    rng = np.random.default_rng(seed=2026)
+    geom = rng.standard_normal((5, 3))   # bohr
+    mode = rng.standard_normal((5, 3))
+    target_A = 0.10
+    displaced = displace_along_mode(geom, mode, amplitude_A=target_A, sign=+1)
+    dx_A = (displaced - geom) * _BOHR_TO_A
+    rms = float(np.sqrt(np.mean(dx_A ** 2)))
+    assert rms == pytest.approx(target_A, rel=1e-9)
+
+
+def test_displace_sign_inversion_is_exact_opposite():
+    rng = np.random.default_rng(2027)
+    geom = rng.standard_normal((4, 3))
+    mode = rng.standard_normal((4, 3))
+    plus = displace_along_mode(geom, mode, amplitude_A=0.05, sign=+1)
+    minus = displace_along_mode(geom, mode, amplitude_A=0.05, sign=-1)
+    # plus + minus == 2 * geom  (exact)
+    assert np.allclose(plus + minus, 2.0 * geom)
+
+
+def test_displace_invalid_sign_raises():
+    geom = np.zeros((2, 3))
+    mode = np.ones((2, 3))
+    with pytest.raises(ValueError, match="sign"):
+        displace_along_mode(geom, mode, amplitude_A=0.1, sign=0)
+
+
+def test_displace_zero_mode_returns_original():
+    geom = np.random.default_rng(0).standard_normal((3, 3))
+    mode = np.zeros((3, 3))
+    out = displace_along_mode(geom, mode, amplitude_A=0.1, sign=+1)
+    assert np.allclose(out, geom)
+
+
+# ---------------------------------------------------------------------------
+# extract_normal_modes_from_hessian_record
+# ---------------------------------------------------------------------------
+
+def test_extract_normal_modes_diagonal_hessian_harmonics():
+    """A diagonal Hessian on a 3-atom linear molecule gives analytical
+    harmonic frequencies. After stripping TR modes we expect 3·N − 5 = 4
+    vibrational frequencies (linear) plus the TR modes correctly removed."""
+    try:
+        from qcelemental.models import Molecule
+    except ImportError:
+        pytest.skip("qcelemental not available")
+
+    # Linear molecule along x: H ... O ... H (centered on O)
+    geom_bohr = np.array([[-1.5, 0.0, 0.0],
+                          [0.0, 0.0, 0.0],
+                          [+1.5, 0.0, 0.0]])
+    symbols = ["H", "O", "H"]
+    masses_amu = [1.00782503207, 15.99491461957, 1.00782503207]
+    mol = Molecule(
+        symbols=symbols, geometry=geom_bohr.flatten(),
+        masses=masses_amu, fix_com=True, fix_orientation=True,
+    )
+    # Diagonal Hessian: equal positive k in every Cartesian direction.
+    k = 0.5
+    hess = k * np.eye(9)
+    freqs, modes = extract_normal_modes_from_hessian_record(hess, mol, energy=0.0)
+    # A linear triatomic gives 3*3 - 5 = 4 vibrations (but identifying
+    # linearity from masses alone isn't done here, so the harmonic_analysis
+    # treats it as non-linear and projects 6 TR modes → 3 vib modes left).
+    # Either way, all non-TR frequencies must be real and finite.
+    assert freqs.size >= 3
+    assert np.all(np.abs(np.imag(freqs)) < 1e-6)
+    assert np.all(np.real(freqs) > 0)
+    assert modes.shape == (freqs.size, 3, 3)
+
+
+def test_extract_normal_modes_returns_aligned_arrays():
+    """Frequencies and mode arrays line up by index."""
+    try:
+        from qcelemental.models import Molecule
+    except ImportError:
+        pytest.skip("qcelemental not available")
+
+    # Diatomic — simplest vibrational case.
+    geom_bohr = np.array([[0.0, 0.0, -0.7], [0.0, 0.0, +0.7]])
+    mol = Molecule(
+        symbols=["H", "H"], geometry=geom_bohr.flatten(),
+        masses=[1.00782503207, 1.00782503207],
+        fix_com=True, fix_orientation=True,
+    )
+    hess = 0.6 * np.eye(6)
+    freqs, modes = extract_normal_modes_from_hessian_record(hess, mol, energy=0.0)
+    assert freqs.shape[0] == modes.shape[0]
+    assert modes.shape[1:] == (2, 3)

--- a/tests/test_qcfractal_adapter.py
+++ b/tests/test_qcfractal_adapter.py
@@ -536,7 +536,10 @@ def test_compute_be_dft_energies_splits_dispersion(mock_submit):
 
 @patch("beep.adapters.qcfractal_adapter.submit_energies")
 def test_compute_be_dft_energies_integrated_for_non_dispersion(mock_submit):
-    """HF-3c has no dispersion suffix → single integrated spec per stoich."""
+    """HF-3c has no dispersion suffix → single integrated spec per stoich.
+    HF-3c is a -3c composite (gCP built into the SCF), so the ``bsse``
+    stoich is intentionally skipped — counterpoise on top would
+    double-correct."""
     from beep.adapters.qcfractal_adapter import compute_be_dft_energies, STOICH_TYPES
 
     mock_submit.return_value = _fake_submit_result()
@@ -548,7 +551,12 @@ def test_compute_be_dft_energies_integrated_for_non_dispersion(mock_submit):
         program="psi4", logger=logger,
     )
 
-    assert mock_submit.call_count == len(STOICH_TYPES)
+    # All stoichs except ``bsse`` get submitted for -3c methods.
+    expected_stoichs = [s for s in STOICH_TYPES if s != "bsse"]
+    assert mock_submit.call_count == len(expected_stoichs)
+    called_stoichs = [call.kwargs["stoich"] for call in mock_submit.call_args_list]
+    assert "bsse" not in called_stoichs
+    assert sorted(called_stoichs) == sorted(expected_stoichs)
     for call in mock_submit.call_args_list:
         assert call.kwargs["method"] == "hf3c"
         assert call.kwargs["basis"] == "minix"
@@ -623,19 +631,19 @@ def test_fetch_reaction_values_d4_separated_pair(mock_ds_name):
 @patch("beep.adapters.qcfractal_adapter._stoich_dataset_name",
        return_value="be_H2O_W5_01_bsse")
 def test_fetch_reaction_values_skips_integrated_spec(mock_ds_name, caplog):
-    """Integrated specs (dispersion suffix before underscore) are skipped with a warning."""
+    """Integrated specs (dispersion suffix before underscore) are filtered out
+    in favour of the canonical separated bare-DFT + bare-dispersion pair.
+    A single summary warning reports the skip count."""
     from beep.adapters.qcfractal_adapter import fetch_reaction_values
 
     records = {
         "pbe_def2-tzvp":           {"entry1": -1.0},
         "pbe-d3bj":                {"entry1": -0.02},
-        "pbe-d3bj_def2-tzvp":      {"entry1": -99.0},   # integrated — should be skipped
+        "pbe-d3bj_def2-tzvp":      {"entry1": -99.0},   # integrated — skipped
     }
     mock_client = MagicMock()
     mock_client.get_dataset.return_value = _fake_reaction_dataset(records)
 
-    # The "beep" logger may have propagate disabled from prior tests — force
-    # propagation so caplog can see the warning.
     import logging
     beep_logger = logging.getLogger("beep")
     prev_propagate = beep_logger.propagate
@@ -646,8 +654,18 @@ def test_fetch_reaction_values_skips_integrated_spec(mock_ds_name, caplog):
     finally:
         beep_logger.propagate = prev_propagate
 
-    assert any("integrated dispersion spec 'pbe-d3bj_def2-tzvp'" in r.message
-               for r in caplog.records)
+    # Composite column came from the separated pair, not the integrated value
+    import qcelemental as qcel
+    conv = qcel.constants.hartree2kcalmol
+    assert "pbe-d3bj/def2-tzvp" in df.columns
+    assert df.loc["entry1", "pbe-d3bj/def2-tzvp"] == pytest.approx(
+        (-1.0 - 0.02) * conv
+    )
+    # Summary warning reports the skip
+    assert any(
+        "Skipped 1 integrated-dispersion spec" in r.message
+        for r in caplog.records
+    )
 
     # Composite column comes from the separated pair, not the skipped integrated value
     import qcelemental as qcel

--- a/tests/test_trajectory_metrics.py
+++ b/tests/test_trajectory_metrics.py
@@ -1,0 +1,271 @@
+"""Tests for beep/core/trajectory_metrics.py."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from beep.core.trajectory_metrics import (
+    per_step_deltas,
+    summarize_method_metrics,
+    combined_zscore_ranking,
+    HARTREE_TO_MEV,
+    HARTREE_PER_BOHR_TO_MEV_PER_A,
+)
+
+
+# ---------------------------------------------------------------------------
+# Conversion constants
+# ---------------------------------------------------------------------------
+
+def test_hartree_to_meV_value():
+    # 1 hartree = 27.2113962 eV = 27211.4 meV (CODATA 2018, 6 sig figs)
+    assert abs(HARTREE_TO_MEV - 27211.386) < 0.01
+
+
+def test_hartree_per_bohr_to_meV_per_A_value():
+    # 1 hartree/bohr ≈ 51422.07 meV/Å
+    assert abs(HARTREE_PER_BOHR_TO_MEV_PER_A - 51422.07) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# per_step_deltas
+# ---------------------------------------------------------------------------
+
+def test_per_step_deltas_zero_diff_is_zero():
+    """Identical ref and DFT inputs → all deltas zero."""
+    e = np.array([-100.0, -100.5, -101.0])
+    g = np.zeros((3, 2, 3))
+    d = per_step_deltas(e, g, e, g, n_atoms=2)
+    assert np.all(d["delta_e_per_atom_meV"] == 0.0)
+    assert np.all(d["delta_force_meV_per_A"] == 0.0)
+
+
+def test_per_step_deltas_energy_per_atom_units():
+    """0.001 hartree total-energy difference on a 2-atom system → ~13.6 meV/atom."""
+    ref_e = np.array([-100.0, -100.5])
+    dft_e = np.array([-100.001, -100.501])   # 0.001 hartree lower
+    g = np.zeros((2, 2, 3))
+    d = per_step_deltas(ref_e, g, dft_e, g, n_atoms=2)
+    expected = -0.001 * HARTREE_TO_MEV / 2.0
+    assert d["delta_e_per_atom_meV"].shape == (2,)
+    assert abs(d["delta_e_per_atom_meV"][0] - expected) < 1e-6
+    assert abs(d["delta_e_per_atom_meV"][1] - expected) < 1e-6
+
+
+def test_per_step_deltas_force_units():
+    """1e-4 hartree/bohr gradient difference → ~5.14 meV/Å per component."""
+    e = np.zeros(1)
+    ref_g = np.zeros((1, 1, 3))
+    dft_g = np.zeros((1, 1, 3))
+    dft_g[0, 0, 0] = 1e-4   # x-component only
+    d = per_step_deltas(e, ref_g, e, dft_g, n_atoms=1)
+    expected = 1e-4 * HARTREE_PER_BOHR_TO_MEV_PER_A
+    assert d["delta_force_meV_per_A"].shape == (1, 1, 3)
+    assert abs(d["delta_force_meV_per_A"][0, 0, 0] - expected) < 1e-6
+    assert d["delta_force_meV_per_A"][0, 0, 1] == 0.0
+    assert d["delta_force_meV_per_A"][0, 0, 2] == 0.0
+
+
+def test_per_step_deltas_shape_mismatch_raises():
+    with pytest.raises(ValueError, match="ref_energies shape"):
+        per_step_deltas(
+            np.array([1.0, 2.0]), np.zeros((2, 1, 3)),
+            np.array([1.0]),       np.zeros((1, 1, 3)),
+            n_atoms=1,
+        )
+
+
+def test_per_step_deltas_gradient_shape_mismatch_raises():
+    with pytest.raises(ValueError, match="ref_gradients shape"):
+        per_step_deltas(
+            np.array([1.0]), np.zeros((1, 2, 3)),
+            np.array([1.0]), np.zeros((1, 3, 3)),
+            n_atoms=2,
+        )
+
+
+def test_per_step_deltas_invalid_n_atoms_raises():
+    with pytest.raises(ValueError, match="n_atoms"):
+        per_step_deltas(
+            np.array([1.0]), np.zeros((1, 1, 3)),
+            np.array([1.0]), np.zeros((1, 1, 3)),
+            n_atoms=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# summarize_method_metrics
+# ---------------------------------------------------------------------------
+
+def test_summarize_empty_returns_nans():
+    s = summarize_method_metrics([])
+    assert np.isnan(s["rmsd_energy"])
+    assert np.isnan(s["rmsd_force"])
+    assert s["n_energy_points"] == 0
+    assert s["n_force_components"] == 0
+
+
+def test_summarize_single_system_constant_delta():
+    """A trajectory with constant +5 meV/atom delta → RMSD = 5."""
+    deltas = {
+        "delta_e_per_atom_meV": np.array([5.0, 5.0, 5.0]),
+        "delta_force_meV_per_A": np.zeros((3, 2, 3)),
+    }
+    s = summarize_method_metrics([deltas])
+    assert s["rmsd_energy"] == 5.0
+    assert s["rmsd_force"] == 0.0
+    assert s["n_energy_points"] == 3
+    assert s["n_force_components"] == 18   # 3 steps × 2 atoms × 3 components
+
+
+def test_summarize_signed_deltas_use_squared_under_root():
+    """+5 and -5 should give RMSD = 5 (signs irrelevant under squaring)."""
+    deltas = {
+        "delta_e_per_atom_meV": np.array([+5.0, -5.0]),
+        "delta_force_meV_per_A": np.zeros((2, 1, 3)),
+    }
+    s = summarize_method_metrics([deltas])
+    assert s["rmsd_energy"] == 5.0
+
+
+def test_summarize_concatenates_systems():
+    """Deltas from two systems with different lengths get concatenated."""
+    a = {
+        "delta_e_per_atom_meV": np.array([2.0, 4.0]),
+        "delta_force_meV_per_A": np.full((2, 1, 3), 1.0),
+    }
+    b = {
+        "delta_e_per_atom_meV": np.array([6.0, 8.0, 10.0]),
+        "delta_force_meV_per_A": np.full((3, 2, 3), 2.0),
+    }
+    s = summarize_method_metrics([a, b])
+    assert s["n_energy_points"] == 5
+    # Force components: 2*1*3 + 3*2*3 = 6 + 18 = 24
+    assert s["n_force_components"] == 24
+    # RMSD energy = sqrt(mean([4, 16, 36, 64, 100])) = sqrt(44)
+    assert abs(s["rmsd_energy"] - np.sqrt(44.0)) < 1e-10
+
+
+def test_summarize_force_rmsd_over_all_components():
+    """Force RMSD is taken over every Cartesian component (n_steps × n_atoms × 3)."""
+    f = np.array([[[1.0, 0.0, 0.0]], [[0.0, 3.0, 0.0]]])   # shape (2, 1, 3)
+    deltas = {
+        "delta_e_per_atom_meV": np.zeros(2),
+        "delta_force_meV_per_A": f,
+    }
+    s = summarize_method_metrics([deltas])
+    # RMSD = sqrt(mean([1, 0, 0, 0, 9, 0])) = sqrt(10/6)
+    assert abs(s["rmsd_force"] - np.sqrt(10.0 / 6.0)) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# combined_zscore_ranking  (weight-driven; works for any metric subset)
+# ---------------------------------------------------------------------------
+
+def _three_method_df():
+    """Standard 2-metric setup matching the geom_benchmark workflow."""
+    return pd.DataFrame(
+        {
+            "rmsd_eq":    [0.04, 0.03, 0.05],
+            "rmsd_force": [25.0, 20.0, 30.0],
+        },
+        index=["B3LYP-D3BJ", "MPWB1K-D3BJ", "M06-2X"],
+    )
+
+
+def _equal_weights():
+    return {"rmsd_eq": 1.0, "rmsd_force": 1.0}
+
+
+def test_combined_zscore_winner():
+    """MPWB1K-D3BJ is best on both dims → must come out top."""
+    ranking = combined_zscore_ranking(_three_method_df(), _equal_weights())
+    assert ranking.index[0] == "MPWB1K-D3BJ"
+
+
+def test_combined_zscore_columns():
+    ranking = combined_zscore_ranking(_three_method_df(), _equal_weights())
+    for col in ("z_rmsd_eq", "z_rmsd_force", "combined_score"):
+        assert col in ranking.columns
+
+
+def test_combined_zscore_sorted_ascending():
+    ranking = combined_zscore_ranking(_three_method_df(), _equal_weights())
+    scores = ranking["combined_score"].to_numpy()
+    assert (np.diff(scores) >= 0).all(), "combined_score should be ascending"
+
+
+def test_combined_zscore_zero_variance_dim_contributes_zero():
+    """A metric where all methods are equal → that z-column is all 0."""
+    df = pd.DataFrame(
+        {
+            "rmsd_eq":    [0.04, 0.04, 0.04],   # flat
+            "rmsd_force": [25.0, 20.0, 30.0],
+        },
+        index=["A", "B", "C"],
+    )
+    ranking = combined_zscore_ranking(df, _equal_weights())
+    assert (ranking["z_rmsd_eq"] == 0.0).all()
+
+
+def test_combined_zscore_weights_change_ranking():
+    """Upweighting force enough should change the winner if a method is
+    bad on force but good on geometry."""
+    df = pd.DataFrame(
+        {
+            "rmsd_eq":    [0.03, 0.04],
+            "rmsd_force": [40.0, 20.0],
+        },
+        index=["good_geom_bad_force", "decent_balanced"],
+    )
+    equal = combined_zscore_ranking(df, _equal_weights())
+    # Equal weights: both are mirror-symmetric on the two dims so score = 0
+    # for both. Tie-break by sort stability — make the test robust by
+    # checking the winner under heavier force weight.
+    assert "good_geom_bad_force" in equal.index
+    force_heavy = combined_zscore_ranking(
+        df, {"rmsd_eq": 1.0, "rmsd_force": 10.0},
+    )
+    assert force_heavy.index[0] == "decent_balanced"
+
+
+def test_combined_zscore_missing_metric_column_raises():
+    df = pd.DataFrame(
+        {"rmsd_eq": [0.04, 0.03]},
+        index=["A", "B"],
+    )
+    with pytest.raises(ValueError, match="rmsd_force"):
+        combined_zscore_ranking(df, _equal_weights())
+
+
+def test_combined_zscore_empty_weights_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        combined_zscore_ranking(_three_method_df(), {})
+
+
+def test_combined_zscore_single_method_zero_score():
+    """One method → std=0 → all z-scores 0 → combined_score 0."""
+    df = pd.DataFrame(
+        {"rmsd_eq": [0.04], "rmsd_force": [25.0]},
+        index=["A"],
+    )
+    ranking = combined_zscore_ranking(df, _equal_weights())
+    assert ranking.loc["A", "combined_score"] == 0.0
+
+
+def test_combined_zscore_handles_arbitrary_metric_set():
+    """Weight-driven: any metric subset present in both df and weights works."""
+    df = pd.DataFrame(
+        {
+            "alpha": [1.0, 2.0, 3.0],
+            "beta":  [5.0, 4.0, 3.0],
+            "gamma": [9.0, 9.0, 9.0],   # zero-variance, ignored
+        },
+        index=["x", "y", "z"],
+    )
+    ranking = combined_zscore_ranking(
+        df, {"alpha": 1.0, "beta": 1.0, "gamma": 1.0},
+    )
+    for col in ("z_alpha", "z_beta", "z_gamma", "combined_score"):
+        assert col in ranking.columns
+    # gamma is zero-variance → contributes 0
+    assert (ranking["z_gamma"] == 0.0).all()


### PR DESCRIPTION
### New workflows

  - **`nm_sampling`** — per-functional force-RMSE benchmark on normal-mode
    displaced geometries. Hessian (default HF/def2-SVP), rigid-body mode
    classifier (inter / bend / stretch), ± displacements, CCSD(T)/aug-cc-pVTZ
    reference gradients, per-band RMSE ranking. Includes `pre_run` mode
    (Molden + JSON without committing the gradient budget) and imaginary-mode
    abort.
  - **Trajectory analysis in `geom_benchmark`** (default-on) — SP + gradient
    at every reference-trajectory geometry; force-RMSD vs reference combined
    with the existing eq-RMSD via weighted z-score ranking.

  ### Added

  - **gCP-corrected BE in `energy_benchmark`** (`gcp_correction: true`) —
    standalone `mctc-gcp` SPs at `dft/def2-tzvp`, post-hoc combined with bare
    DFT energies. Restricted to gCP-compatible functionals.
  - Per-group MAE output for all `energy_benchmark` tables.

  ### Fixed

  - **`be_hess`** — bypass Psi4's default ADIIS warmup
    (`scf_initial_accelerator: NONE`). ADIIS on Psi4 1.10 caused intermittent
    SCF failures; pure DIIS converges to the same energy (Δ < 1e-13 Ha
    verified). Only affects new submissions.

  ## Tests

  299/299 passing. New: `test_normal_mode_sampling.py`,
  `test_trajectory_metrics.py`.
