### PR TITLE
  Route be_hess Hessian submissions to ORCA with translated dispersion keywords adaption of extract worfklow to orca

### DIFF
--- a/beep/adapters/qcfractal_adapter.py
+++ b/beep/adapters/qcfractal_adapter.py
@@ -1131,6 +1131,55 @@ def _has_dispersion_suffix(name: str) -> bool:
     return any(m.endswith(s) for s in DISPERSION_SUFFIXES)
 
 
+# psi4/dftd3-style dispersion suffix -> native ORCA simple-input keyword.
+# ORCA has no keyword for Grimme's modified-damping -d3m/-d3mbj variants,
+# so those raise instead of silently computing with the wrong damping.
+ORCA_DISPERSION_KEYWORDS: Dict[str, str] = {
+    "-d4": "D4",
+    "-d3bj": "D3BJ",
+    "-d3": "D3ZERO",
+}
+
+
+def hessian_method_and_keywords(method: str, mult: int, program: str) -> Tuple[str, dict]:
+    """Return the (method, keywords) pair for a Hessian submission on ``program``.
+
+    psi4 (default): the method string is passed through unchanged — psi4
+    parses dispersion suffixes itself, so Hessians include the dispersion
+    derivative contribution — with psi4-style keywords (``dertype 1``,
+    ``reference uks`` for open shells).
+
+    orca: the compound method is split into the bare functional plus the
+    native ORCA dispersion keyword on the harness's ``simple_input`` escape
+    hatch (e.g. ``b3lyp-d4`` -> method ``b3lyp``, ``simple_input: "D4"``),
+    because ORCA rejects psi4-style compound method strings. The Hessian
+    physics matches the psi4 workflow: the same Grimme library supplies the
+    dispersion second derivatives, just invoked by ORCA. Only the BE-*energy*
+    stage keeps dispersion in separate dftd3/dftd4 records. The psi4-style
+    keywords are dropped: ORCA's ``Freq`` is analytic and UKS follows from
+    the molecule multiplicity.
+    """
+    if program.lower() == "orca":
+        bare, disp_method, _ = _split_dispersion(method)
+        if disp_method is None:
+            return bare, {}
+        suffix = disp_method[len(bare):].lower()
+        try:
+            orca_kw = ORCA_DISPERSION_KEYWORDS[suffix]
+        except KeyError:
+            raise ValueError(
+                f"Dispersion variant '{suffix}' of method '{method}' has no native "
+                f"ORCA keyword (ORCA supports {sorted(ORCA_DISPERSION_KEYWORDS)}); "
+                "choose a supported variant or run this level of theory with psi4."
+            )
+        return bare, {"simple_input": orca_kw}
+
+    kw: dict = {"function_kwargs": {"dertype": 1}}
+    if mult != 1:
+        kw["reference"] = "uks"
+    return method, kw
+
+
 def compute_be_dft_energies(
     client: PortalClient,
     rdset_base_name: str,
@@ -1298,11 +1347,9 @@ def compute_hessian(
         max_rows=5,
     )
 
-    logger.info(f"\nWill compute Hessian at {method}/{basis} level of theory")
-    kw = {"function_kwargs": {"dertype": 1}}
-    if mult != 1:
-        kw["reference"] = "uks"
+    method, kw = hessian_method_and_keywords(method, mult, program)
 
+    logger.info(f"\nWill compute Hessian at {method}/{basis} level of theory")
     logger.info(f"\nComputing Hessian at {method}/{basis} level of theory")
     logger.info(f"Using keywords: {kw}")
 
@@ -1395,6 +1442,29 @@ def get_zpve_mol(client: PortalClient, mol, lot_opt: str,
         basis=basis,
         status=RecordStatusEnum.complete,
     ))
+
+    # ORCA Hessians of dispersion-corrected LOTs are stored under the *bare*
+    # functional with the native dispersion keyword on simple_input (see
+    # hessian_method_and_keywords), so the compound-method query above cannot
+    # see them. Query the bare method on orca and keep only records whose
+    # simple_input carries the matching dispersion keyword.
+    bare, disp_method, _ = _split_dispersion(method)
+    if disp_method is not None:
+        orca_kw = ORCA_DISPERSION_KEYWORDS.get(disp_method[len(bare):].lower())
+        if orca_kw is not None:
+            orca_results = client.query_singlepoints(
+                driver=SinglepointDriver.hessian,
+                molecule_id=mol,
+                method=bare,
+                basis=basis,
+                program="orca",
+                status=RecordStatusEnum.complete,
+            )
+            results.extend(
+                r for r in orca_results
+                if orca_kw in str(r.specification.keywords.get("simple_input", "")).upper().split()
+            )
+
     # Defensive: even a "complete" record can have None properties if the
     # server is in an inconsistent state (e.g. mid-write). Skip those —
     # `result.return_result` dereferences properties and would crash.

--- a/beep/workflows/be_hess.py
+++ b/beep/workflows/be_hess.py
@@ -161,7 +161,9 @@ def process_be_computation(client, logger, finished_opt_list, surf_opt_ds,
         )
 
         keyword = None
-        if mult != 1:
+        if mult != 1 and config.program.lower() != "orca":
+            # psi4-style option; the ORCA harness rejects unknown keywords
+            # and ORCA selects UKS automatically from the multiplicity.
             keyword = {"reference": "uks"}
 
         padded_log(logger, f"Sending computations for {rdset_name}", padding_char="*", total_length=60)

--- a/tests/test_qcfractal_adapter.py
+++ b/tests/test_qcfractal_adapter.py
@@ -253,8 +253,35 @@ def test_get_zpve_mol_filters_incomplete_records():
 
     # Verify the query was made with status=complete, narrowing to
     # server-side completes before we even client-side filter.
-    kwargs = mock_client.query_singlepoints.call_args.kwargs
+    kwargs = mock_client.query_singlepoints.call_args_list[0].kwargs
     assert kwargs["status"] == RecordStatusEnum.complete
+
+
+def test_get_zpve_mol_finds_orca_bare_method_hessian():
+    """ORCA Hessians of dispersion LOTs are stored under the bare functional
+    with the dispersion keyword in simple_input; get_zpve_mol must fall back
+    to that query shape when the compound-method query returns nothing."""
+    mock_client = MagicMock()
+
+    mock_mol = MagicMock()
+    mock_mol.symbols = ["O", "H", "H"]
+    mock_mol.dict.return_value = {"identifiers": {"molecular_formula": "H2O"}}
+    mock_client.get_molecules.return_value = [mock_mol]
+
+    orca_record = MagicMock()
+    orca_record.specification.keywords = {"simple_input": "D3BJ"}
+    # No compound-method record (first call), one orca bare-method record (second call)
+    mock_client.query_singlepoints.side_effect = [iter([]), iter([orca_record])]
+
+    # Interrupt before the vibrational analysis: we only care about record lookup
+    with patch("beep.core.zpve._vibanal_wfn", side_effect=RuntimeError("stop")):
+        with pytest.raises(RuntimeError, match="stop"):
+            get_zpve_mol(mock_client, 12345, "mpwb1k-d3bj_def2-tzvpd")
+
+    calls = mock_client.query_singlepoints.call_args_list
+    assert calls[0].kwargs["method"] == "mpwb1k-d3bj"
+    assert calls[1].kwargs["method"] == "mpwb1k"
+    assert calls[1].kwargs["program"] == "orca"
 
 
 @patch("beep.adapters.qcfractal_adapter.time.sleep", lambda *a, **kw: None)
@@ -493,6 +520,35 @@ def test_fetch_atom_molecule_not_found():
 def test_split_dispersion(method, expected):
     from beep.adapters.qcfractal_adapter import _split_dispersion
     assert _split_dispersion(method) == expected
+
+
+@pytest.mark.parametrize(
+    "method, mult, program, expected",
+    [
+        # psi4: method passes through (psi4 parses dispersion suffixes itself)
+        ("b3lyp-d4", 1, "psi4", ("b3lyp-d4", {"function_kwargs": {"dertype": 1}})),
+        ("mpwb1k-d3bj", 2, "psi4",
+         ("mpwb1k-d3bj", {"function_kwargs": {"dertype": 1}, "reference": "uks"})),
+        ("pbe", 1, "psi4", ("pbe", {"function_kwargs": {"dertype": 1}})),
+        # orca: bare functional + native dispersion keyword via simple_input;
+        # no psi4 keywords, UKS implicit
+        ("b3lyp-d4", 1, "orca", ("b3lyp", {"simple_input": "D4"})),
+        ("mpwb1k-d3bj", 2, "orca", ("mpwb1k", {"simple_input": "D3BJ"})),
+        ("pbe-d3", 1, "orca", ("pbe", {"simple_input": "D3ZERO"})),
+        ("pbe", 1, "orca", ("pbe", {})),
+        ("b3lyp-d4", 1, "ORCA", ("b3lyp", {"simple_input": "D4"})),  # case-insensitive program
+    ],
+)
+def test_hessian_method_and_keywords(method, mult, program, expected):
+    from beep.adapters.qcfractal_adapter import hessian_method_and_keywords
+    assert hessian_method_and_keywords(method, mult, program) == expected
+
+
+@pytest.mark.parametrize("method", ["b3lyp-d3m", "b3lyp-d3mbj"])
+def test_hessian_method_and_keywords_orca_unsupported_damping(method):
+    from beep.adapters.qcfractal_adapter import hessian_method_and_keywords
+    with pytest.raises(ValueError, match="no native"):
+        hessian_method_and_keywords(method, 1, "orca")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  Adds `hessian_method_and_keywords()` in the QCFractal adapter: when the spec's `program` is `orca`, splits the compound method (e.g. `b3lyp-d4`) into the
  bare functional plus ORCA's native simple-input keyword (`D4` / `D3BJ` / `D3ZERO`), so ORCA accepts the level of theory instead of choking on the psi4-style
  compound name. Raises on `-d3m` / `-d3mbj` variants that ORCA has no keyword for. psi4 path is unchanged (compound method passed through as before).

  `be_hess` now routes through the new helper, so the same workflow spec can drive Hessians on either program.
 
  Small addition, three files touched — new tests in `tests/test_qcfractal_adapter.py` cover the mapping and the unsupported-variant error path.
