### PR TITLE
Add Gaussian program support with dispersion keyword table

### DIFF
--- a/beep/adapters/qcfractal_adapter.py
+++ b/beep/adapters/qcfractal_adapter.py
@@ -1131,14 +1131,22 @@ def _has_dispersion_suffix(name: str) -> bool:
     return any(m.endswith(s) for s in DISPERSION_SUFFIXES)
 
 
-# psi4/dftd3-style dispersion suffix -> native ORCA simple-input keyword.
-# ORCA has no keyword for Grimme's modified-damping -d3m/-d3mbj variants,
-# so those raise instead of silently computing with the wrong damping.
-ORCA_DISPERSION_KEYWORDS: Dict[str, str] = {
-    "-d4": "D4",
-    "-d3bj": "D3BJ",
-    "-d3": "D3ZERO",
+# psi4/dftd3-style dispersion suffix -> (harness keyword field, native keyword
+# token) per program. Programs listed here store dispersion-corrected Hessians
+# as bare functional + native dispersion keyword; the dict's insertion order is
+# also the query order of the get_zpve_mol fallback (keep it deterministic).
+# Variants absent for a program (ORCA: -d3m/-d3mbj; Gaussian: -d4/-d3m/-d3mbj)
+# raise instead of silently computing with the wrong damping.
+DISPERSION_KEYWORD_SPEC: Dict[str, Tuple[str, Dict[str, str]]] = {
+    "orca": ("simple_input", {"-d4": "D4", "-d3bj": "D3BJ", "-d3": "D3ZERO"}),
+    "gaussian": ("route_input", {"-d3bj": "EmpiricalDispersion=GD3BJ", "-d3": "EmpiricalDispersion=GD3"}),
 }
+
+
+def _keyword_token_match(kw_value: Any, token: str) -> bool:
+    """Case-insensitive exact-token match of ``token`` inside a route/simple
+    keyword string (whitespace-split, so ``GD3`` never matches ``GD3BJ``)."""
+    return token.upper() in str(kw_value).upper().split()
 
 
 def hessian_method_and_keywords(method: str, mult: int, program: str) -> Tuple[str, dict]:
@@ -1149,30 +1157,34 @@ def hessian_method_and_keywords(method: str, mult: int, program: str) -> Tuple[s
     derivative contribution — with psi4-style keywords (``dertype 1``,
     ``reference uks`` for open shells).
 
-    orca: the compound method is split into the bare functional plus the
-    native ORCA dispersion keyword on the harness's ``simple_input`` escape
-    hatch (e.g. ``b3lyp-d4`` -> method ``b3lyp``, ``simple_input: "D4"``),
-    because ORCA rejects psi4-style compound method strings. The Hessian
-    physics matches the psi4 workflow: the same Grimme library supplies the
-    dispersion second derivatives, just invoked by ORCA. Only the BE-*energy*
-    stage keeps dispersion in separate dftd3/dftd4 records. The psi4-style
-    keywords are dropped: ORCA's ``Freq`` is analytic and UKS follows from
-    the molecule multiplicity.
+    orca / gaussian (any program in ``DISPERSION_KEYWORD_SPEC``): the compound
+    method is split into the bare functional plus the program's native
+    dispersion keyword on the harness's escape-hatch field (e.g. ``b3lyp-d4``
+    -> orca ``simple_input: "D4"``; ``b3lyp-d3bj`` -> gaussian
+    ``route_input: "EmpiricalDispersion=GD3BJ"``), because those harnesses
+    reject psi4-style compound method strings. The Hessian physics matches
+    the psi4 workflow — the same Grimme library supplies the dispersion
+    second derivatives. Only the BE-*energy* stage keeps dispersion in
+    separate dftd3/dftd4 records. The psi4-style keywords are dropped: both
+    programs' Hessians are analytic and UKS/UHF follows from the molecule
+    multiplicity.
     """
-    if program.lower() == "orca":
+    spec = DISPERSION_KEYWORD_SPEC.get(program.lower())
+    if spec is not None:
+        field, table = spec
         bare, disp_method, _ = _split_dispersion(method)
         if disp_method is None:
             return bare, {}
         suffix = disp_method[len(bare):].lower()
         try:
-            orca_kw = ORCA_DISPERSION_KEYWORDS[suffix]
+            native_kw = table[suffix]
         except KeyError:
             raise ValueError(
                 f"Dispersion variant '{suffix}' of method '{method}' has no native "
-                f"ORCA keyword (ORCA supports {sorted(ORCA_DISPERSION_KEYWORDS)}); "
+                f"{program} keyword ({program} supports {sorted(table)}); "
                 "choose a supported variant or run this level of theory with psi4."
             )
-        return bare, {"simple_input": orca_kw}
+        return bare, {field: native_kw}
 
     kw: dict = {"function_kwargs": {"dertype": 1}}
     if mult != 1:
@@ -1443,26 +1455,30 @@ def get_zpve_mol(client: PortalClient, mol, lot_opt: str,
         status=RecordStatusEnum.complete,
     ))
 
-    # ORCA Hessians of dispersion-corrected LOTs are stored under the *bare*
-    # functional with the native dispersion keyword on simple_input (see
-    # hessian_method_and_keywords), so the compound-method query above cannot
-    # see them. Query the bare method on orca and keep only records whose
-    # simple_input carries the matching dispersion keyword.
+    # orca/gaussian Hessians of dispersion-corrected LOTs are stored under the
+    # *bare* functional with the native dispersion keyword on the harness's
+    # escape-hatch field (see hessian_method_and_keywords), so the
+    # compound-method query above cannot see them. Query the bare method per
+    # program (DISPERSION_KEYWORD_SPEC insertion order) and keep only records
+    # whose keyword field carries the matching dispersion token.
     bare, disp_method, _ = _split_dispersion(method)
     if disp_method is not None:
-        orca_kw = ORCA_DISPERSION_KEYWORDS.get(disp_method[len(bare):].lower())
-        if orca_kw is not None:
-            orca_results = client.query_singlepoints(
+        suffix = disp_method[len(bare):].lower()
+        for prog, (field, table) in DISPERSION_KEYWORD_SPEC.items():
+            native_kw = table.get(suffix)
+            if native_kw is None:
+                continue
+            prog_results = client.query_singlepoints(
                 driver=SinglepointDriver.hessian,
                 molecule_id=mol,
                 method=bare,
                 basis=basis,
-                program="orca",
+                program=prog,
                 status=RecordStatusEnum.complete,
             )
             results.extend(
-                r for r in orca_results
-                if orca_kw in str(r.specification.keywords.get("simple_input", "")).upper().split()
+                r for r in prog_results
+                if _keyword_token_match(r.specification.keywords.get(field, ""), native_kw)
             )
 
     # Defensive: even a "complete" record can have None properties if the

--- a/beep/workflows/be_hess.py
+++ b/beep/workflows/be_hess.py
@@ -161,9 +161,9 @@ def process_be_computation(client, logger, finished_opt_list, surf_opt_ds,
         )
 
         keyword = None
-        if mult != 1 and config.program.lower() != "orca":
-            # psi4-style option; the ORCA harness rejects unknown keywords
-            # and ORCA selects UKS automatically from the multiplicity.
+        if mult != 1 and config.program.lower() == "psi4":
+            # psi4-only option; the ORCA and Gaussian harnesses reject unknown
+            # keywords and select UKS/UHF automatically from the multiplicity.
             keyword = {"reference": "uks"}
 
         padded_log(logger, f"Sending computations for {rdset_name}", padding_char="*", total_length=60)

--- a/tests/test_qcfractal_adapter.py
+++ b/tests/test_qcfractal_adapter.py
@@ -257,21 +257,28 @@ def test_get_zpve_mol_filters_incomplete_records():
     assert kwargs["status"] == RecordStatusEnum.complete
 
 
-def test_get_zpve_mol_finds_orca_bare_method_hessian():
-    """ORCA Hessians of dispersion LOTs are stored under the bare functional
-    with the dispersion keyword in simple_input; get_zpve_mol must fall back
-    to that query shape when the compound-method query returns nothing."""
+def _zpve_mock_client():
     mock_client = MagicMock()
-
     mock_mol = MagicMock()
     mock_mol.symbols = ["O", "H", "H"]
     mock_mol.dict.return_value = {"identifiers": {"molecular_formula": "H2O"}}
     mock_client.get_molecules.return_value = [mock_mol]
+    return mock_client
+
+
+def test_get_zpve_mol_finds_orca_bare_method_hessian():
+    """ORCA Hessians of dispersion LOTs are stored under the bare functional
+    with the dispersion keyword in simple_input; get_zpve_mol must fall back
+    to that query shape when the compound-method query returns nothing.
+
+    The fallback queries every program in DISPERSION_KEYWORD_SPEC that knows
+    the suffix, in insertion order (orca, then gaussian for -d3bj)."""
+    mock_client = _zpve_mock_client()
 
     orca_record = MagicMock()
     orca_record.specification.keywords = {"simple_input": "D3BJ"}
-    # No compound-method record (first call), one orca bare-method record (second call)
-    mock_client.query_singlepoints.side_effect = [iter([]), iter([orca_record])]
+    # calls: compound-method (empty), orca bare-method (hit), gaussian bare-method (empty)
+    mock_client.query_singlepoints.side_effect = [iter([]), iter([orca_record]), iter([])]
 
     # Interrupt before the vibrational analysis: we only care about record lookup
     with patch("beep.core.zpve._vibanal_wfn", side_effect=RuntimeError("stop")):
@@ -282,6 +289,41 @@ def test_get_zpve_mol_finds_orca_bare_method_hessian():
     assert calls[0].kwargs["method"] == "mpwb1k-d3bj"
     assert calls[1].kwargs["method"] == "mpwb1k"
     assert calls[1].kwargs["program"] == "orca"
+    assert calls[2].kwargs["program"] == "gaussian"
+
+
+def test_get_zpve_mol_finds_gaussian_bare_method_hessian():
+    """Gaussian Hessians store the dispersion keyword in route_input
+    (e.g. 'EmpiricalDispersion=GD3BJ'); the token filter must accept the
+    matching record and reject a different-damping one (GD3 vs GD3BJ)."""
+    mock_client = _zpve_mock_client()
+
+    gau_record = MagicMock()
+    gau_record.specification.keywords = {"route_input": "EmpiricalDispersion=GD3BJ SCF=Tight"}
+    wrong_damping = MagicMock()
+    wrong_damping.specification.keywords = {"route_input": "EmpiricalDispersion=GD3"}
+    # calls: compound-method (empty), orca (empty), gaussian (one hit + one filtered out)
+    mock_client.query_singlepoints.side_effect = [iter([]), iter([]), iter([wrong_damping, gau_record])]
+
+    with patch("beep.core.zpve._vibanal_wfn", side_effect=RuntimeError("stop")):
+        with pytest.raises(RuntimeError, match="stop"):
+            get_zpve_mol(mock_client, 12345, "b3lyp-d3bj_def2-svp")
+
+    calls = mock_client.query_singlepoints.call_args_list
+    assert calls[2].kwargs["method"] == "b3lyp"
+    assert calls[2].kwargs["program"] == "gaussian"
+
+
+def test_keyword_token_match():
+    from beep.adapters.qcfractal_adapter import _keyword_token_match
+
+    assert _keyword_token_match("D3BJ", "D3BJ")
+    assert _keyword_token_match("d3bj tightscf", "D3BJ")
+    assert _keyword_token_match("EmpiricalDispersion=GD3BJ SCF=Tight", "EmpiricalDispersion=GD3BJ")
+    # exact-token: GD3 must not match GD3BJ and vice versa
+    assert not _keyword_token_match("EmpiricalDispersion=GD3BJ", "EmpiricalDispersion=GD3")
+    assert not _keyword_token_match("EmpiricalDispersion=GD3", "EmpiricalDispersion=GD3BJ")
+    assert not _keyword_token_match("", "D4")
 
 
 @patch("beep.adapters.qcfractal_adapter.time.sleep", lambda *a, **kw: None)
@@ -537,6 +579,12 @@ def test_split_dispersion(method, expected):
         ("pbe-d3", 1, "orca", ("pbe", {"simple_input": "D3ZERO"})),
         ("pbe", 1, "orca", ("pbe", {})),
         ("b3lyp-d4", 1, "ORCA", ("b3lyp", {"simple_input": "D4"})),  # case-insensitive program
+        # gaussian: bare functional + native dispersion keyword via route_input;
+        # no psi4 keywords, UHF/UKS implicit
+        ("b3lyp-d3bj", 1, "gaussian", ("b3lyp", {"route_input": "EmpiricalDispersion=GD3BJ"})),
+        ("pbe-d3", 2, "gaussian", ("pbe", {"route_input": "EmpiricalDispersion=GD3"})),
+        ("pbe", 1, "gaussian", ("pbe", {})),
+        ("b3lyp-d3bj", 1, "Gaussian", ("b3lyp", {"route_input": "EmpiricalDispersion=GD3BJ"})),
     ],
 )
 def test_hessian_method_and_keywords(method, mult, program, expected):
@@ -544,11 +592,20 @@ def test_hessian_method_and_keywords(method, mult, program, expected):
     assert hessian_method_and_keywords(method, mult, program) == expected
 
 
-@pytest.mark.parametrize("method", ["b3lyp-d3m", "b3lyp-d3mbj"])
-def test_hessian_method_and_keywords_orca_unsupported_damping(method):
+@pytest.mark.parametrize(
+    "method, program",
+    [
+        ("b3lyp-d3m", "orca"),
+        ("b3lyp-d3mbj", "orca"),
+        ("b3lyp-d4", "gaussian"),  # G16 has no D4
+        ("b3lyp-d3m", "gaussian"),
+        ("b3lyp-d3mbj", "gaussian"),
+    ],
+)
+def test_hessian_method_and_keywords_unsupported_damping(method, program):
     from beep.adapters.qcfractal_adapter import hessian_method_and_keywords
     with pytest.raises(ValueError, match="no native"):
-        hessian_method_and_keywords(method, 1, "orca")
+        hessian_method_and_keywords(method, 1, program)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  Extends the ORCA program support from #32 to Gaussian 16, by generalizing the
  dispersion handling into a single per-program table. With this PR, be_hess runs
  with `program: "gaussian"` behave the same as psi4 and orca for a given
  compound LOT such as `b3lyp-d3bj_def2-svp`.

  ## Changes

  - `adapters/qcfractal_adapter.py`:
    - `ORCA_DISPERSION_KEYWORDS` is replaced by `DISPERSION_KEYWORD_SPEC`, mapping
      each program to its harness keyword field and native dispersion tokens:
      orca uses `simple_input` (D4, D3BJ, D3ZERO), gaussian uses `route_input`
      (EmpiricalDispersion=GD3BJ, EmpiricalDispersion=GD3). Variants a program
      does not support (gaussian has no D4, neither has D3M/D3MBJ) raise a
      ValueError instead of silently computing with wrong damping.
    - `hessian_method_and_keywords` now consults the table. psi4 and orca
      behavior is unchanged (existing parametrized tests pass untouched).
    - The `get_zpve_mol` bare-method fallback now queries every program in the
      table and filters records with an exact-token keyword match, so GD3 can
      never match GD3BJ.
  - `workflows/be_hess.py`: the open-shell `{"reference": "uks"}` injection is
    now psi4-only. Both the ORCA and Gaussian harnesses reject unknown keywords
    and select UKS/UHF from the molecule multiplicity.
  - `tests/test_qcfractal_adapter.py`: gaussian rows in both parametrized suites,
    a gaussian clone of the zpve fallback test with a wrong-damping negative
    record, and unit tests for the token matcher.

  ## Testing

  - Full suite: 378 passed.
  - Requires the Gaussian harness from the QCEngine fork
    (stvogt/QCEngine branch `gaussian-harness`) in the worker environment;
    smoke tested 64/64 against G16 RevB.01 on nothung.
